### PR TITLE
General: general cleanup

### DIFF
--- a/include/boo/graphicsdev/D3D.hpp
+++ b/include/boo/graphicsdev/D3D.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 #include <unordered_set>
 
-typedef HRESULT(WINAPI* pD3DCreateBlob)(SIZE_T Size, ID3DBlob** ppBlob);
+using pD3DCreateBlob = HRESULT(WINAPI*)(SIZE_T Size, ID3DBlob** ppBlob);
 extern pD3DCreateBlob D3DCreateBlobPROC;
 
 namespace boo {

--- a/include/boo/inputdev/DeviceBase.hpp
+++ b/include/boo/inputdev/DeviceBase.hpp
@@ -54,18 +54,18 @@ public:
   bool sendUSBInterruptTransfer(const uint8_t* data, size_t length);
   size_t receiveUSBInterruptTransfer(uint8_t* data, size_t length);
 
-  inline unsigned getVendorId();
-  inline unsigned getProductId();
-  inline std::string_view getVendorName();
-  inline std::string_view getProductName();
+  inline unsigned getVendorId() const;
+  inline unsigned getProductId() const;
+  inline std::string_view getVendorName() const;
+  inline std::string_view getProductName() const;
 
   /* High-Level API */
 #if _WIN32
 #if !WINDOWS_STORE
-  const PHIDP_PREPARSED_DATA getReportDescriptor();
+  PHIDP_PREPARSED_DATA getReportDescriptor() const;
 #endif
 #else
-  std::vector<uint8_t> getReportDescriptor();
+  std::vector<uint8_t> getReportDescriptor() const;
 #endif
   bool sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message = 0);
   size_t receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp,

--- a/include/boo/inputdev/DeviceFinder.hpp
+++ b/include/boo/inputdev/DeviceFinder.hpp
@@ -41,11 +41,8 @@ private:
 
   /* Friend methods for platform-listener to find/insert/remove
    * tokens with type-filtering */
-  bool _hasToken(const std::string& path) {
-    auto preCheck = m_tokens.find(path);
-    if (preCheck != m_tokens.end())
-      return true;
-    return false;
+  bool _hasToken(const std::string& path) const {
+    return m_tokens.find(path) != m_tokens.end();
   }
   bool _insertToken(std::unique_ptr<DeviceToken>&& token) {
     if (DeviceSignature::DeviceMatchToken(*token, m_types)) {
@@ -77,8 +74,12 @@ public:
   public:
     CDeviceTokensHandle(DeviceFinder& finder) : m_finder(finder) { m_finder.m_tokensLock.lock(); }
     ~CDeviceTokensHandle() { m_finder.m_tokensLock.unlock(); }
-    TDeviceTokens::iterator begin() { return m_finder.m_tokens.begin(); }
-    TDeviceTokens::iterator end() { return m_finder.m_tokens.end(); }
+
+    TDeviceTokens::iterator begin() noexcept { return m_finder.m_tokens.begin(); }
+    TDeviceTokens::iterator end() noexcept { return m_finder.m_tokens.end(); }
+
+    TDeviceTokens::const_iterator begin() const noexcept { return m_finder.m_tokens.begin(); }
+    TDeviceTokens::const_iterator end() const noexcept { return m_finder.m_tokens.end(); }
   };
 
   /* Application must specify its interested device-types */

--- a/include/boo/inputdev/DeviceSignature.hpp
+++ b/include/boo/inputdev/DeviceSignature.hpp
@@ -16,8 +16,9 @@ class DeviceBase;
 #define dev_typeid(type) std::hash<std::string>()(#type)
 
 struct DeviceSignature {
-  typedef std::vector<const DeviceSignature*> TDeviceSignatureSet;
-  typedef std::function<std::shared_ptr<DeviceBase>(DeviceToken*)> TFactoryLambda;
+  using TDeviceSignatureSet = std::vector<const DeviceSignature*>;
+  using TFactoryLambda = std::function<std::shared_ptr<DeviceBase>(DeviceToken*)>;
+
   const char* m_name = nullptr;
   uint64_t m_typeHash = 0;
   unsigned m_vid = 0;

--- a/include/boo/inputdev/DeviceSignature.hpp
+++ b/include/boo/inputdev/DeviceSignature.hpp
@@ -18,12 +18,13 @@ class DeviceBase;
 struct DeviceSignature {
   typedef std::vector<const DeviceSignature*> TDeviceSignatureSet;
   typedef std::function<std::shared_ptr<DeviceBase>(DeviceToken*)> TFactoryLambda;
-  const char* m_name;
-  uint64_t m_typeHash;
-  unsigned m_vid, m_pid;
+  const char* m_name = nullptr;
+  uint64_t m_typeHash = 0;
+  unsigned m_vid = 0;
+  unsigned m_pid = 0;
   TFactoryLambda m_factory;
-  DeviceType m_type;
-  DeviceSignature() : m_name(NULL), m_typeHash(dev_typeid(DeviceSignature)) {} /* Sentinel constructor */
+  DeviceType m_type{};
+  DeviceSignature() : m_typeHash(dev_typeid(DeviceSignature)) {} /* Sentinel constructor */
   DeviceSignature(const char* name, uint64_t typeHash, unsigned vid, unsigned pid, TFactoryLambda&& factory,
                   DeviceType type = DeviceType::None)
   : m_name(name), m_typeHash(typeHash), m_vid(vid), m_pid(pid), m_factory(factory), m_type(type) {}

--- a/include/boo/inputdev/DualshockPad.hpp
+++ b/include/boo/inputdev/DualshockPad.hpp
@@ -136,7 +136,7 @@ public:
 
   void stopRumble(int motor) { m_rumbleRequest &= ~EDualshockMotor(motor); }
 
-  EDualshockLED getLED() { return m_led; }
+  EDualshockLED getLED() const { return m_led; }
 
   void setLED(EDualshockLED led, bool on = true) {
     if (on)

--- a/include/boo/inputdev/IHIDListener.hpp
+++ b/include/boo/inputdev/IHIDListener.hpp
@@ -5,10 +5,10 @@
 #include "DeviceToken.hpp"
 
 namespace boo {
-
-typedef std::unordered_map<std::string, std::unique_ptr<DeviceToken>> TDeviceTokens;
-typedef std::pair<TDeviceTokens::iterator, bool> TInsertedDeviceToken;
 class DeviceFinder;
+
+using TDeviceTokens = std::unordered_map<std::string, std::unique_ptr<DeviceToken>>;
+using TInsertedDeviceToken = std::pair<TDeviceTokens::iterator, bool>;
 
 class IHIDListener {
 public:

--- a/include/boo/inputdev/NintendoPowerA.hpp
+++ b/include/boo/inputdev/NintendoPowerA.hpp
@@ -23,8 +23,8 @@ struct NintendoPowerAState {
   uint8_t leftY;
   uint8_t rightX;
   uint8_t rightY;
-  bool operator==(const NintendoPowerAState& other);
-  bool operator!=(const NintendoPowerAState& other);
+  bool operator==(const NintendoPowerAState& other) const;
+  bool operator!=(const NintendoPowerAState& other) const;
 };
 
 class NintendoPowerA;

--- a/lib/audiodev/AQS.cpp
+++ b/lib/audiodev/AQS.cpp
@@ -78,11 +78,11 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
                  CFStringGetCStringPtr(devName, kCFStringEncodingUTF8));
       argSize = sizeof(devId);
       propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-      if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, NULL, &argSize, &devId) == noErr) {
+      if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &argSize, &devId) == noErr) {
         argSize = sizeof(CFStringRef);
         AudioObjectPropertyAddress deviceAddress;
         deviceAddress.mSelector = kAudioDevicePropertyDeviceUID;
-        AudioObjectGetPropertyData(devId, &deviceAddress, 0, NULL, &argSize, &m_devName);
+        AudioObjectGetPropertyData(devId, &deviceAddress, 0, nullptr, &argSize, &m_devName);
       } else {
         Log.report(logvisor::Fatal, fmt("unable determine default audio device"));
         return {AudioChannelSet::Unknown, 48000.0};
@@ -90,21 +90,21 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
     }
 
     propertyAddress.mSelector = kAudioDevicePropertyStreams;
-    if (AudioObjectGetPropertyDataSize(devId, &propertyAddress, 0, NULL, &argSize) == noErr) {
+    if (AudioObjectGetPropertyDataSize(devId, &propertyAddress, 0, nullptr, &argSize) == noErr) {
       numStreams = argSize / sizeof(AudioStreamID);
       streamIDs.resize(numStreams);
 
-      if (AudioObjectGetPropertyData(devId, &propertyAddress, 0, NULL, &argSize, &streamIDs[0]) == noErr) {
+      if (AudioObjectGetPropertyData(devId, &propertyAddress, 0, nullptr, &argSize, &streamIDs[0]) == noErr) {
         propertyAddress.mSelector = kAudioStreamPropertyDirection;
         for (int stm = 0; stm < numStreams; stm++) {
           UInt32 streamDir;
           argSize = sizeof(streamDir);
-          if (AudioObjectGetPropertyData(streamIDs[stm], &propertyAddress, 0, NULL, &argSize, &streamDir) == noErr) {
+          if (AudioObjectGetPropertyData(streamIDs[stm], &propertyAddress, 0, nullptr, &argSize, &streamDir) == noErr) {
             if (streamDir == 0) {
               propertyAddress.mSelector = kAudioStreamPropertyPhysicalFormat;
               AudioStreamBasicDescription asbd;
               argSize = sizeof(asbd);
-              if (AudioObjectGetPropertyData(streamIDs[stm], &propertyAddress, 0, NULL, &argSize, &asbd) == noErr) {
+              if (AudioObjectGetPropertyData(streamIDs[stm], &propertyAddress, 0, nullptr, &argSize, &asbd) == noErr) {
                 switch (asbd.mChannelsPerFrame) {
                 case 2:
                   return {AudioChannelSet::Stereo, asbd.mSampleRate};
@@ -155,29 +155,29 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
     propertyAddress.mSelector = kAudioHardwarePropertyDevices;
     propertyAddress.mScope = kAudioObjectPropertyScopeGlobal;
     propertyAddress.mElement = kAudioObjectPropertyElementMaster;
-    if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &propertyAddress, 0, NULL, &propertySize) == noErr) {
+    if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &propertySize) == noErr) {
       numDevices = propertySize / sizeof(AudioDeviceID);
       ret.reserve(numDevices);
       deviceIDs.resize(numDevices);
 
-      if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, NULL, &propertySize,
+      if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &propertySize,
                                      &deviceIDs[0]) == noErr) {
         char deviceName[64];
 
         for (int idx = 0; idx < numDevices; idx++) {
           propertyAddress.mSelector = kAudioDevicePropertyStreams;
-          if (AudioObjectGetPropertyDataSize(deviceIDs[idx], &propertyAddress, 0, NULL, &propertySize) == noErr) {
+          if (AudioObjectGetPropertyDataSize(deviceIDs[idx], &propertyAddress, 0, nullptr, &propertySize) == noErr) {
             numStreams = propertySize / sizeof(AudioStreamID);
             streamIDs.resize(numStreams);
 
-            if (AudioObjectGetPropertyData(deviceIDs[idx], &propertyAddress, 0, NULL, &propertySize, &streamIDs[0]) ==
+            if (AudioObjectGetPropertyData(deviceIDs[idx], &propertyAddress, 0, nullptr, &propertySize, &streamIDs[0]) ==
                 noErr) {
               propertyAddress.mSelector = kAudioStreamPropertyDirection;
               bool foundOutput = false;
               for (int stm = 0; stm < numStreams; stm++) {
                 UInt32 streamDir;
                 propertySize = sizeof(streamDir);
-                if (AudioObjectGetPropertyData(streamIDs[stm], &propertyAddress, 0, NULL, &propertySize, &streamDir) ==
+                if (AudioObjectGetPropertyData(streamIDs[stm], &propertyAddress, 0, nullptr, &propertySize, &streamDir) ==
                     noErr) {
                   if (streamDir == 0) {
                     foundOutput = true;
@@ -192,13 +192,13 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
 
           propertySize = sizeof(deviceName);
           propertyAddress.mSelector = kAudioDevicePropertyDeviceName;
-          if (AudioObjectGetPropertyData(deviceIDs[idx], &propertyAddress, 0, NULL, &propertySize, deviceName) ==
+          if (AudioObjectGetPropertyData(deviceIDs[idx], &propertyAddress, 0, nullptr, &propertySize, deviceName) ==
               noErr) {
             CFPointer<CFStringRef> uidString;
 
             propertySize = sizeof(CFStringRef);
             propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
-            if (AudioObjectGetPropertyData(deviceIDs[idx], &propertyAddress, 0, NULL, &propertySize, &uidString) ==
+            if (AudioObjectGetPropertyData(deviceIDs[idx], &propertyAddress, 0, nullptr, &propertySize, &uidString) ==
                 noErr) {
               ret.emplace_back(CFStringGetCStringPtr(uidString.get(), kCFStringEncodingUTF8), deviceName);
             }
@@ -800,11 +800,11 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
                                      const AudioObjectPropertyAddress* inAddresses, AQSAudioVoiceEngine* engine) {
     AudioObjectID defaultDeviceId;
     UInt32 argSize = sizeof(defaultDeviceId);
-    if (AudioObjectGetPropertyData(inObjectID, inAddresses, 0, NULL, &argSize, &defaultDeviceId) == noErr) {
+    if (AudioObjectGetPropertyData(inObjectID, inAddresses, 0, nullptr, &argSize, &defaultDeviceId) == noErr) {
       argSize = sizeof(CFStringRef);
       AudioObjectPropertyAddress deviceAddress;
       deviceAddress.mSelector = kAudioDevicePropertyDeviceUID;
-      AudioObjectGetPropertyData(defaultDeviceId, &deviceAddress, 0, NULL, &argSize, &engine->m_devName);
+      AudioObjectGetPropertyData(defaultDeviceId, &deviceAddress, 0, nullptr, &argSize, &engine->m_devName);
     }
     engine->m_needsRebuild = true;
     return noErr;
@@ -820,12 +820,12 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
     AudioObjectID defaultDeviceId;
     UInt32 argSize = sizeof(defaultDeviceId);
     propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-    if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, NULL, &argSize, &defaultDeviceId) ==
+    if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &argSize, &defaultDeviceId) ==
         noErr) {
       argSize = sizeof(CFStringRef);
       AudioObjectPropertyAddress deviceAddress;
       deviceAddress.mSelector = kAudioDevicePropertyDeviceUID;
-      AudioObjectGetPropertyData(defaultDeviceId, &deviceAddress, 0, NULL, &argSize, &m_devName);
+      AudioObjectGetPropertyData(defaultDeviceId, &deviceAddress, 0, nullptr, &argSize, &m_devName);
     } else {
       Log.report(logvisor::Fatal, fmt("unable determine default audio device"));
       return;

--- a/lib/audiodev/AudioMatrixSSE.cpp
+++ b/lib/audiodev/AudioMatrixSSE.cpp
@@ -6,13 +6,13 @@
 
 namespace boo {
 
-typedef union {
+union TVectorUnion {
   float v[4];
 #if __SSE__
   __m128 q;
   __m64 d[2];
 #endif
-} TVectorUnion;
+};
 
 static constexpr TVectorUnion Min32Vec = {{INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN}};
 static constexpr TVectorUnion Max32Vec = {{INT32_MAX, INT32_MAX, INT32_MAX, INT32_MAX}};

--- a/lib/audiodev/WASAPI.cpp
+++ b/lib/audiodev/WASAPI.cpp
@@ -12,12 +12,12 @@
 
 #ifdef TE_VIRTUAL_MIDI
 #include <teVirtualMIDI.h>
-typedef LPVM_MIDI_PORT(CALLBACK* pfnvirtualMIDICreatePortEx2)(LPCWSTR portName, LPVM_MIDI_DATA_CB callback,
+using pfnvirtualMIDICreatePortEx2 = LPVM_MIDI_PORT(CALLBACK*)(LPCWSTR portName, LPVM_MIDI_DATA_CB callback,
                                                               DWORD_PTR dwCallbackInstance, DWORD maxSysexLength,
                                                               DWORD flags);
-typedef void(CALLBACK* pfnvirtualMIDIClosePort)(LPVM_MIDI_PORT midiPort);
-typedef BOOL(CALLBACK* pfnvirtualMIDISendData)(LPVM_MIDI_PORT midiPort, LPBYTE midiDataBytes, DWORD length);
-typedef LPCWSTR(CALLBACK* pfnvirtualMIDIGetDriverVersion)(PWORD major, PWORD minor, PWORD release, PWORD build);
+using pfnvirtualMIDIClosePort = void(CALLBACK*)(LPVM_MIDI_PORT midiPort);
+using pfnvirtualMIDISendData = BOOL(CALLBACK*)(LPVM_MIDI_PORT midiPort, LPBYTE midiDataBytes, DWORD length);
+using pfnvirtualMIDIGetDriverVersion = LPCWSTR(CALLBACK*)(PWORD major, PWORD minor, PWORD release, PWORD build);
 static pfnvirtualMIDICreatePortEx2 virtualMIDICreatePortEx2PROC = nullptr;
 static pfnvirtualMIDIClosePort virtualMIDIClosePortPROC = nullptr;
 static pfnvirtualMIDISendData virtualMIDISendDataPROC = nullptr;

--- a/lib/audiodev/WASAPI.cpp
+++ b/lib/audiodev/WASAPI.cpp
@@ -38,9 +38,9 @@ namespace boo {
 static logvisor::Module Log("boo::WASAPI");
 
 #define SAFE_RELEASE(punk)                                                                                             \
-  if ((punk) != NULL) {                                                                                                \
+  if ((punk) != nullptr) {                                                                                             \
     (punk)->Release();                                                                                                 \
-    (punk) = NULL;                                                                                                     \
+    (punk) = nullptr;                                                                                                  \
   }
 
 struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
@@ -90,7 +90,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
         AddRef();
         *ppvInterface = (IMMNotificationClient*)this;
       } else {
-        *ppvInterface = NULL;
+        *ppvInterface = nullptr;
         return E_NOINTERFACE;
       }
       return S_OK;
@@ -303,7 +303,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
         AddRef();
         *ppvInterface = (IActivateAudioInterfaceCompletionHandler*)this;
       } else {
-        *ppvInterface = NULL;
+        *ppvInterface = nullptr;
         return E_NOINTERFACE;
       }
       return S_OK;
@@ -663,7 +663,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
       m_hdr.dwBufferLength = 512;
       m_hdr.dwFlags = MHDR_ISSTRM;
       midiOutPrepareHeader(m_midi, &m_hdr, sizeof(m_hdr));
-      midiStreamOpen(&m_strm, &id, 1, NULL, NULL, CALLBACK_NULL);
+      midiStreamOpen(&m_strm, &id, 1, 0, 0, CALLBACK_NULL);
     }
 
     ~MIDIOut() override {
@@ -712,7 +712,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
       m_hdr.dwBufferLength = 512;
       m_hdr.dwFlags = MHDR_ISSTRM;
       midiOutPrepareHeader(m_midiOut, &m_hdr, sizeof(m_hdr));
-      midiStreamOpen(&m_strm, &id, 1, NULL, NULL, CALLBACK_NULL);
+      midiStreamOpen(&m_strm, &id, 1, 0, 0, CALLBACK_NULL);
     }
 
     ~MIDIInOut() override {
@@ -835,7 +835,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
     if (!ret)
       return {};
 
-    if (FAILED(midiOutOpen(&static_cast<MIDIOut&>(*ret).m_midi, id, NULL, NULL, CALLBACK_NULL)))
+    if (FAILED(midiOutOpen(&static_cast<MIDIOut&>(*ret).m_midi, id, 0, 0, CALLBACK_NULL)))
       return {};
 
     static_cast<MIDIOut&>(*ret).prepare();
@@ -861,7 +861,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
       return {};
     midiInStart(static_cast<MIDIInOut&>(*ret).m_midiIn);
 
-    if (FAILED(midiOutOpen(&static_cast<MIDIInOut&>(*ret).m_midiOut, outId, NULL, NULL, CALLBACK_NULL)))
+    if (FAILED(midiOutOpen(&static_cast<MIDIInOut&>(*ret).m_midiOut, outId, 0, 0, CALLBACK_NULL)))
       return {};
 
     static_cast<MIDIInOut&>(*ret).prepare();

--- a/lib/graphicsdev/Common.hpp
+++ b/lib/graphicsdev/Common.hpp
@@ -249,7 +249,7 @@ public:
     m_backcv.wait(lk, [this]() { return m_outstandingTasks == 0 || !m_running; });
   }
 
-  bool isReady() {
+  bool isReady() const {
     return m_outstandingTasks == 0 || !m_running;
   }
 

--- a/lib/graphicsdev/Vulkan.cpp
+++ b/lib/graphicsdev/Vulkan.cpp
@@ -188,7 +188,7 @@ static void SetImageLayout(VkCommandBuffer cmd, VkImage image, VkImageAspectFlag
                            uint32_t layerCount, uint32_t baseMipLevel = 0) {
   VkImageMemoryBarrier imageMemoryBarrier = {};
   imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-  imageMemoryBarrier.pNext = NULL;
+  imageMemoryBarrier.pNext = nullptr;
   imageMemoryBarrier.srcAccessMask = 0;
   imageMemoryBarrier.dstAccessMask = 0;
   imageMemoryBarrier.oldLayout = old_image_layout;
@@ -261,7 +261,7 @@ static void SetImageLayout(VkCommandBuffer cmd, VkImage image, VkImageAspectFlag
     break;
   }
 
-  vk::CmdPipelineBarrier(cmd, src_stages, dest_stages, 0, 0, NULL, 0, NULL, 1, &imageMemoryBarrier);
+  vk::CmdPipelineBarrier(cmd, src_stages, dest_stages, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
 }
 
 static VkResult InitGlobalExtensionProperties(VulkanContext::LayerProperties& layerProps) {

--- a/lib/graphicsdev/nx/NX.cpp
+++ b/lib/graphicsdev/nx/NX.cpp
@@ -1801,7 +1801,7 @@ bool NXContext::initialize() {
 
   gfxInitDefault();
   gfxSetMode(GfxMode_TiledDouble);
-  consoleInit(NULL);
+  consoleInit(nullptr);
   printf("Activated console\n\n");
   m_screen = nouveau_switch_screen_create();
   if (!m_screen) {

--- a/lib/inputdev/DeviceBase.cpp
+++ b/lib/inputdev/DeviceBase.cpp
@@ -37,25 +37,25 @@ size_t DeviceBase::receiveUSBInterruptTransfer(uint8_t* data, size_t length) {
   return false;
 }
 
-unsigned DeviceBase::getVendorId() {
+unsigned DeviceBase::getVendorId() const {
   if (m_token)
     return m_token->getVendorId();
   return -1;
 }
 
-unsigned DeviceBase::getProductId() {
+unsigned DeviceBase::getProductId() const {
   if (m_token)
     return m_token->getProductId();
   return -1;
 }
 
-std::string_view DeviceBase::getVendorName() {
+std::string_view DeviceBase::getVendorName() const {
   if (m_token)
     return m_token->getVendorName();
   return {};
 }
 
-std::string_view DeviceBase::getProductName() {
+std::string_view DeviceBase::getProductName() const {
   if (m_token)
     return m_token->getProductName();
   return {};
@@ -63,14 +63,14 @@ std::string_view DeviceBase::getProductName() {
 
 #if _WIN32
 #if !WINDOWS_STORE
-const PHIDP_PREPARSED_DATA DeviceBase::getReportDescriptor() {
+PHIDP_PREPARSED_DATA DeviceBase::getReportDescriptor() const {
   if (m_hidDev)
     return m_hidDev->_getReportDescriptor();
   return {};
 }
 #endif
 #else
-std::vector<uint8_t> DeviceBase::getReportDescriptor() {
+std::vector<uint8_t> DeviceBase::getReportDescriptor() const {
   if (m_hidDev)
     return m_hidDev->_getReportDescriptor();
   return {};

--- a/lib/inputdev/HIDDeviceBSD.cpp
+++ b/lib/inputdev/HIDDeviceBSD.cpp
@@ -8,13 +8,12 @@ class HIDListenerBSD final : public IHIDListener {
 
 public:
   HIDListenerBSD(DeviceFinder& finder) : m_finder(finder) {}
+  ~HIDListenerBSD() override = default;
 
-  ~HIDListenerBSD() {}
+  bool startScanning() override { return false; }
+  bool stopScanning() override { return false; }
 
-  bool startScanning() { return false; }
-  bool stopScanning() { return false; }
-
-  bool scanNow() { return false; }
+  bool scanNow() override { return false; }
 };
 
 IHIDListener* IHIDListenerNew(DeviceFinder& finder) { return new HIDListenerBSD(finder); }

--- a/lib/inputdev/HIDDeviceIOKit.cpp
+++ b/lib/inputdev/HIDDeviceIOKit.cpp
@@ -23,7 +23,7 @@ class HIDDeviceIOKit : public IHIDDevice {
   std::condition_variable m_initCond;
   std::thread m_thread;
 
-  bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) {
+  bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) override {
     if (m_usbIntf) {
       IOReturn res = m_usbIntf->WritePipe(m_usbIntf.storage(), m_usbIntfOutPipe, (void*)data, length);
       return res == kIOReturnSuccess;
@@ -31,7 +31,7 @@ class HIDDeviceIOKit : public IHIDDevice {
     return false;
   }
 
-  size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) {
+  size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) override {
     if (m_usbIntf) {
       UInt32 readSize = length;
       IOReturn res = m_usbIntf->ReadPipe(m_usbIntf.storage(), m_usbIntfInPipe, data, &readSize);
@@ -42,7 +42,7 @@ class HIDDeviceIOKit : public IHIDDevice {
     return 0;
   }
 
-  std::vector<uint8_t> _getReportDescriptor() {
+  std::vector<uint8_t> _getReportDescriptor() override {
     if (m_hidIntf) {
       if (CFTypeRef desc = IOHIDDeviceGetProperty(m_hidIntf.get(), CFSTR(kIOHIDReportDescriptorKey))) {
         CFIndex len = CFDataGetLength(CFDataRef(desc));
@@ -54,7 +54,7 @@ class HIDDeviceIOKit : public IHIDDevice {
     return {};
   }
 
-  bool _sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) {
+  bool _sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override {
     /* HACK: A bug in IOBluetoothGamepadHIDDriver prevents raw output report transmission
      * USB driver appears to work correctly */
     if (m_hidIntf && !m_isBt) {
@@ -64,7 +64,7 @@ class HIDDeviceIOKit : public IHIDDevice {
     return false;
   }
 
-  size_t _receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp, uint32_t message) {
+  size_t _receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override {
     if (m_hidIntf) {
       CFIndex readSize = length;
       IOReturn res = IOHIDDeviceGetReport(m_hidIntf.get(), IOHIDReportType(tp), message, data, &readSize);
@@ -273,13 +273,13 @@ class HIDDeviceIOKit : public IHIDDevice {
     device->m_hidIntf.reset();
   }
 
-  void _deviceDisconnected() { m_runningTransferLoop = false; }
+  void _deviceDisconnected() override { m_runningTransferLoop = false; }
 
 public:
   HIDDeviceIOKit(DeviceToken& token, const std::shared_ptr<DeviceBase>& devImp)
   : m_token(token), m_devImp(devImp), m_devPath(token.getDevicePath()) {}
 
-  void _startThread() {
+  void _startThread() override {
     std::unique_lock<std::mutex> lk(m_initMutex);
     DeviceType dType = m_token.getDeviceType();
     if (dType == DeviceType::USB)
@@ -295,7 +295,7 @@ public:
     m_initCond.wait(lk);
   }
 
-  ~HIDDeviceIOKit() {
+  ~HIDDeviceIOKit() override {
     m_runningTransferLoop = false;
     if (m_thread.joinable())
       m_thread.detach();

--- a/lib/inputdev/HIDDeviceNX.cpp
+++ b/lib/inputdev/HIDDeviceNX.cpp
@@ -11,13 +11,13 @@ public:
   HIDDeviceNX(DeviceToken& token, const std::shared_ptr<DeviceBase>& devImp)
   : m_token(token), m_devImp(devImp), m_devPath(token.getDevicePath()) {}
 
-  void _deviceDisconnected() {}
-  bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) { return false; }
-  size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) { return 0; }
-  std::vector<uint8_t> _getReportDescriptor() { return {}; }
-  bool _sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) { return false; }
-  size_t _receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp, uint32_t message) { return 0; }
-  void _startThread() {}
+  void _deviceDisconnected() override {}
+  bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) override { return false; }
+  size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) override { return 0; }
+  std::vector<uint8_t> _getReportDescriptor() override { return {}; }
+  bool _sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override { return false; }
+  size_t _receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override { return 0; }
+  void _startThread() override {}
 };
 
 std::shared_ptr<IHIDDevice> IHIDDeviceNew(DeviceToken& token, const std::shared_ptr<DeviceBase>& devImp) {

--- a/lib/inputdev/HIDDeviceUWP.cpp
+++ b/lib/inputdev/HIDDeviceUWP.cpp
@@ -9,12 +9,12 @@ class HIDDeviceUWP : public IHIDDevice {
 public:
   HIDDeviceUWP(DeviceToken& token, const std::shared_ptr<DeviceBase>& devImp) {}
 
-  void _deviceDisconnected() {}
-  bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) { return false; }
-  size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) { return 0; }
-  bool _sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) { return false; }
-  size_t _receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp, uint32_t message) { return false; }
-  void _startThread() {}
+  void _deviceDisconnected() override {}
+  bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) override { return false; }
+  size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) override { return 0; }
+  bool _sendHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override { return false; }
+  size_t _receiveHIDReport(uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override { return false; }
+  void _startThread() override {}
 };
 
 std::shared_ptr<IHIDDevice> IHIDDeviceNew(DeviceToken& token, const std::shared_ptr<DeviceBase>& devImp) {

--- a/lib/inputdev/HIDDeviceUdev.cpp
+++ b/lib/inputdev/HIDDeviceUdev.cpp
@@ -102,7 +102,7 @@ class HIDDeviceUdev final : public IHIDDevice {
     }
 
     /* Request that kernel disconnects existing driver */
-    usbdevfs_ioctl disconnectReq = {0, USBDEVFS_DISCONNECT, NULL};
+    usbdevfs_ioctl disconnectReq = {0, USBDEVFS_DISCONNECT, nullptr};
     ioctl(fd, USBDEVFS_IOCTL, &disconnectReq);
 
     /* Return control to main thread */

--- a/lib/inputdev/HIDDeviceWinUSB.cpp
+++ b/lib/inputdev/HIDDeviceWinUSB.cpp
@@ -27,8 +27,8 @@ class HIDDeviceWinUSB final : public IHIDDevice {
   DeviceToken& m_token;
   std::shared_ptr<DeviceBase> m_devImp;
 
-  HANDLE m_devHandle = 0;
-  HANDLE m_hidHandle = 0;
+  HANDLE m_devHandle = nullptr;
+  HANDLE m_hidHandle = nullptr;
   WINUSB_INTERFACE_HANDLE m_usbHandle = nullptr;
   unsigned m_usbIntfInPipe = 0;
   unsigned m_usbIntfOutPipe = 0;
@@ -42,9 +42,10 @@ class HIDDeviceWinUSB final : public IHIDDevice {
   bool _sendUSBInterruptTransfer(const uint8_t* data, size_t length) override {
     if (m_usbHandle) {
       ULONG lengthTransferred = 0;
-      if (!WinUsb_WritePipe(m_usbHandle, m_usbIntfOutPipe, (PUCHAR)data, (ULONG)length, &lengthTransferred, NULL) ||
-          lengthTransferred != length)
+      if (!WinUsb_WritePipe(m_usbHandle, m_usbIntfOutPipe, (PUCHAR)data, (ULONG)length, &lengthTransferred, nullptr) ||
+          lengthTransferred != length) {
         return false;
+      }
       return true;
     }
     return false;
@@ -53,7 +54,7 @@ class HIDDeviceWinUSB final : public IHIDDevice {
   size_t _receiveUSBInterruptTransfer(uint8_t* data, size_t length) override {
     if (m_usbHandle) {
       ULONG lengthTransferred = 0;
-      if (!WinUsb_ReadPipe(m_usbHandle, m_usbIntfInPipe, (PUCHAR)data, (ULONG)length, &lengthTransferred, NULL))
+      if (!WinUsb_ReadPipe(m_usbHandle, m_usbIntfInPipe, (PUCHAR)data, (ULONG)length, &lengthTransferred, nullptr))
         return 0;
       return lengthTransferred;
     }
@@ -66,8 +67,8 @@ class HIDDeviceWinUSB final : public IHIDDevice {
 
     /* POSIX.. who needs it?? -MS */
     device->m_devHandle =
-        CreateFileA(device->m_devPath.data(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_WRITE | FILE_SHARE_READ, NULL,
-                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, NULL);
+        CreateFileA(device->m_devPath.data(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_WRITE | FILE_SHARE_READ, nullptr,
+                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
     if (INVALID_HANDLE_VALUE == device->m_devHandle) {
       device->m_devImp->deviceError(fmt("Unable to open {}@{}: {}\n"),
         device->m_token.getProductName(), device->m_devPath, GetLastError());
@@ -150,8 +151,8 @@ class HIDDeviceWinUSB final : public IHIDDevice {
     /* POSIX.. who needs it?? -MS */
     device->m_overlapped.hEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
     device->m_hidHandle =
-        CreateFileA(device->m_devPath.data(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_WRITE | FILE_SHARE_READ, NULL,
-                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, NULL);
+        CreateFileA(device->m_devPath.data(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_WRITE | FILE_SHARE_READ, nullptr,
+                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
     if (INVALID_HANDLE_VALUE == device->m_hidHandle) {
       device->m_devImp->deviceError(fmt("Unable to open {}@{}: {}\n"),
         device->m_token.getProductName(), device->m_devPath, GetLastError());

--- a/lib/inputdev/HIDListenerBSD.cpp
+++ b/lib/inputdev/HIDListenerBSD.cpp
@@ -16,8 +16,7 @@ class HIDDeviceBSD final : public IHIDDevice {
 
 public:
   HIDDeviceBSD(DeviceToken& token, DeviceBase& devImp) : m_token(token), m_devImp(devImp) {}
-
-  ~HIDDeviceBSD() {}
+  ~HIDDeviceBSD() override = default;
 };
 
 std::shared_ptr<IHIDDevice> IHIDDeviceNew(DeviceToken& token, const std::shared_ptr<DeviceBase>& devImp) {

--- a/lib/inputdev/HIDListenerIOKit.cpp
+++ b/lib/inputdev/HIDListenerIOKit.cpp
@@ -263,23 +263,23 @@ public:
     m_scanningEnabled = false;
   }
 
-  ~HIDListenerIOKit() {
+  ~HIDListenerIOKit() override {
     // CFRunLoopRemoveSource(m_listenerRunLoop, IONotificationPortGetRunLoopSource(m_llPort), kCFRunLoopDefaultMode);
     IONotificationPortDestroy(m_llPort);
   }
 
   /* Automatic device scanning */
-  bool startScanning() {
+  bool startScanning() override {
     m_scanningEnabled = true;
     return true;
   }
-  bool stopScanning() {
+  bool stopScanning() override {
     m_scanningEnabled = false;
     return true;
   }
 
   /* Manual device scanning */
-  bool scanNow() {
+  bool scanNow() override {
     IOObjectPointer<io_iterator_t> iter;
     if (IOServiceGetMatchingServices(kIOMasterPortDefault, IOServiceMatching(m_usbClass), &iter) == kIOReturnSuccess) {
       devicesConnectedUSBLL(this, iter.get());

--- a/lib/inputdev/HIDListenerNX.cpp
+++ b/lib/inputdev/HIDListenerNX.cpp
@@ -8,9 +8,9 @@ class HIDListenerNX : public IHIDListener {
 public:
   HIDListenerNX(DeviceFinder& finder) : m_finder(finder) {}
 
-  bool startScanning() { return false; }
-  bool stopScanning() { return false; }
-  bool scanNow() { return false; }
+  bool startScanning() override { return false; }
+  bool stopScanning() override { return false; }
+  bool scanNow() override { return false; }
 };
 
 std::unique_ptr<IHIDListener> IHIDListenerNew(DeviceFinder& finder) { return std::make_unique<HIDListenerNX>(finder); }

--- a/lib/inputdev/HIDListenerUWP.cpp
+++ b/lib/inputdev/HIDListenerUWP.cpp
@@ -9,11 +9,11 @@ public:
   HIDListenerUWP(DeviceFinder& finder) {}
 
   /* Automatic device scanning */
-  bool startScanning() { return false; }
-  bool stopScanning() { return false; }
+  bool startScanning() override { return false; }
+  bool stopScanning() override { return false; }
 
   /* Manual device scanning */
-  bool scanNow() { return false; }
+  bool scanNow() override { return false; }
 };
 
 std::unique_ptr<IHIDListener> IHIDListenerNew(DeviceFinder& finder) { return std::make_unique<HIDListenerUWP>(finder); }

--- a/lib/inputdev/HIDListenerUdev.cpp
+++ b/lib/inputdev/HIDListenerUdev.cpp
@@ -187,7 +187,7 @@ public:
     m_udevThread = std::thread(std::bind(&HIDListenerUdev::_udevProc, this), this);
   }
 
-  ~HIDListenerUdev() {
+  ~HIDListenerUdev() override {
     pthread_cancel(m_udevThread.native_handle());
     if (m_udevThread.joinable())
       m_udevThread.join();
@@ -195,17 +195,17 @@ public:
   }
 
   /* Automatic device scanning */
-  bool startScanning() {
+  bool startScanning() override {
     m_scanningEnabled = true;
     return true;
   }
-  bool stopScanning() {
+  bool stopScanning() override {
     m_scanningEnabled = false;
     return true;
   }
 
   /* Manual device scanning */
-  bool scanNow() {
+  bool scanNow() override {
     udev_enumerate* uenum = udev_enumerate_new(GetUdev());
     udev_enumerate_add_match_subsystem(uenum, "usb");
     udev_enumerate_add_match_subsystem(uenum, "bluetooth");

--- a/lib/inputdev/HIDListenerWinUSB.cpp
+++ b/lib/inputdev/HIDListenerWinUSB.cpp
@@ -51,17 +51,17 @@ class HIDListenerWinUSB final : public IHIDListener {
     CHAR szVid[MAX_DEVICE_ID_LEN], szPid[MAX_DEVICE_ID_LEN], szMi[MAX_DEVICE_ID_LEN];
 
     /* List all connected HID devices */
-    hDevInfo = SetupDiGetClassDevs(NULL, 0, 0, DIGCF_PRESENT | DIGCF_ALLCLASSES | DIGCF_DEVICEINTERFACE);
+    hDevInfo = SetupDiGetClassDevs(nullptr, 0, 0, DIGCF_PRESENT | DIGCF_ALLCLASSES | DIGCF_DEVICEINTERFACE);
     if (hDevInfo == INVALID_HANDLE_VALUE)
       return;
 
     for (i = 0;; ++i) {
-      if (!SetupDiEnumDeviceInterfaces(hDevInfo, NULL, TypeGUID, i, &DeviceInterfaceData))
+      if (!SetupDiEnumDeviceInterfaces(hDevInfo, nullptr, TypeGUID, i, &DeviceInterfaceData))
         break;
 
       DeviceInterfaceDetailData.wtf.cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
       if (!SetupDiGetDeviceInterfaceDetailA(hDevInfo, &DeviceInterfaceData, &DeviceInterfaceDetailData.wtf,
-                                            sizeof(DeviceInterfaceDetailData), NULL, &DeviceInfoData))
+                                            sizeof(DeviceInterfaceDetailData), nullptr, &DeviceInfoData))
         continue;
 
       r = CM_Get_Device_IDA(DeviceInfoData.DevInst, szDeviceInstanceID, MAX_PATH, 0);
@@ -73,7 +73,7 @@ class HIDListenerWinUSB final : public IHIDListener {
       szVid[0] = '\0';
       szPid[0] = '\0';
       szMi[0] = '\0';
-      while (pszToken != NULL) {
+      while (pszToken != nullptr) {
         for (j = 0; j < 3; ++j) {
           if (strncmp(pszToken, arPrefix[j], 4) == 0) {
             switch (j) {
@@ -91,14 +91,14 @@ class HIDListenerWinUSB final : public IHIDListener {
             }
           }
         }
-        pszToken = strtok_s(NULL, "\\#&", &pszNextToken);
+        pszToken = strtok_s(nullptr, "\\#&", &pszNextToken);
       }
 
       if (!szVid[0] || !szPid[0])
         continue;
 
-      unsigned vid = strtol(szVid + 4, NULL, 16);
-      unsigned pid = strtol(szPid + 4, NULL, 16);
+      unsigned vid = strtol(szVid + 4, nullptr, 16);
+      unsigned pid = strtol(szPid + 4, nullptr, 16);
 
       CHAR productW[1024] = {0};
       // CHAR product[1024] = {0};
@@ -121,8 +121,8 @@ class HIDListenerWinUSB final : public IHIDListener {
 
       if (type == DeviceType::HID) {
         HANDLE devHnd = CreateFileA(DeviceInterfaceDetailData.wtf.DevicePath, GENERIC_WRITE | GENERIC_READ,
-                                    FILE_SHARE_WRITE | FILE_SHARE_READ, NULL, OPEN_EXISTING,
-                                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, NULL);
+                                    FILE_SHARE_WRITE | FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
         if (INVALID_HANDLE_VALUE == devHnd)
           continue;
         PHIDP_PREPARSED_DATA preparsedData;

--- a/lib/inputdev/NintendoPowerA.cpp
+++ b/lib/inputdev/NintendoPowerA.cpp
@@ -33,12 +33,10 @@ void NintendoPowerA::finalCycle() {}
 
 void NintendoPowerA::receivedHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) {}
 
-bool NintendoPowerAState::operator==(const NintendoPowerAState& other) {
-  return !memcmp(this, &other, sizeof(NintendoPowerAState));
+bool NintendoPowerAState::operator==(const NintendoPowerAState& other) const {
+  return memcmp(this, &other, sizeof(NintendoPowerAState)) == 0;
 }
 
-bool NintendoPowerAState::operator!=(const NintendoPowerAState& other) {
-  return memcmp(this, &other, sizeof(NintendoPowerAState));
-}
+bool NintendoPowerAState::operator!=(const NintendoPowerAState& other) const { return !operator==(other); }
 
 } // namespace boo

--- a/lib/mac/WindowCocoa.mm
+++ b/lib/mac/WindowCocoa.mm
@@ -93,7 +93,7 @@ static const NSOpenGLPixelFormatAttribute PF_RGBAF32_Z24_ATTRS[] =
 
 static const NSOpenGLPixelFormatAttribute* PF_TABLE[] =
 {
-    NULL,
+    nullptr,
     PF_RGBA8_ATTRS,
     PF_RGBA16_ATTRS,
     PF_RGBA8_Z24_ATTRS,
@@ -330,15 +330,15 @@ IGraphicsContext* _GraphicsContextCocoaGLNew(IGraphicsContext::EGraphicsAPI api,
                                              GLContext* glCtx)
 {
     if (api != IGraphicsContext::EGraphicsAPI::OpenGL3_3 && api != IGraphicsContext::EGraphicsAPI::OpenGL4_2)
-        return NULL;
+        return nullptr;
 
     /* Create temporary context to query GL version */
     NSOpenGLPixelFormat* nspf = [[NSOpenGLPixelFormat alloc] initWithAttributes:PF_RGBA8_ATTRS];
     if (!nspf)
-        return NULL;
+        return nullptr;
     NSOpenGLContext* nsctx = [[NSOpenGLContext alloc] initWithFormat:nspf shareContext:nil];
     if (!nsctx)
-        return NULL;
+        return nullptr;
     [nsctx makeCurrentContext];
     const char* glVersion = (char*)glGetString(GL_VERSION);
     unsigned major = 0;
@@ -352,13 +352,13 @@ IGraphicsContext* _GraphicsContextCocoaGLNew(IGraphicsContext::EGraphicsAPI api,
         Log.report(logvisor::Fatal, fmt("glewInit failed"));
     [NSOpenGLContext clearCurrentContext];
     if (!glVersion)
-        return NULL;
+        return nullptr;
 
     if (major > 4 || (major == 4 && minor >= 2))
         api = IGraphicsContext::EGraphicsAPI::OpenGL4_2;
     else if (major == 3 && minor >= 3)
         if (api == IGraphicsContext::EGraphicsAPI::OpenGL4_2)
-            return NULL;
+            return nullptr;
 
     return new GraphicsContextCocoaGL(api, parentWindow, lastGLCtx, glCtx);
 }

--- a/lib/win/ApplicationUWP.cpp
+++ b/lib/win/ApplicationUWP.cpp
@@ -60,7 +60,7 @@ public:
   , m_pname(pname)
   , m_args(args)
   , m_singleInstance(singleInstance) {
-    typedef HRESULT(WINAPI * CreateDXGIFactory1PROC)(REFIID riid, _COM_Outptr_ void** ppFactory);
+    using CreateDXGIFactory1PROC = HRESULT (WINAPI *)(REFIID riid, _COM_Outptr_ void** ppFactory);
     CreateDXGIFactory1PROC MyCreateDXGIFactory1 = CreateDXGIFactory1;
 
     bool no12 = true;

--- a/lib/win/ApplicationUWP.cpp
+++ b/lib/win/ApplicationUWP.cpp
@@ -222,7 +222,7 @@ public:
   void _setWindow(CoreWindow ^ window) { m_window = _WindowUWPNew(m_friendlyName, m_3dCtx); }
 };
 
-IApplication* APP = NULL;
+IApplication* APP = nullptr;
 ref class AppView sealed : public IFrameworkView {
   ApplicationUWP m_app;
 

--- a/lib/win/ApplicationWin32.cpp
+++ b/lib/win/ApplicationWin32.cpp
@@ -340,7 +340,7 @@ public:
       MONITORINFO monitor_info;
       monitor_info.cbSize = sizeof(monitor_info);
       GetMonitorInfo(MonitorFromWindow(win.m_hwnd, MONITOR_DEFAULTTONEAREST), &monitor_info);
-      SetWindowPos(win.m_hwnd, NULL, monitor_info.rcMonitor.left, monitor_info.rcMonitor.top,
+      SetWindowPos(win.m_hwnd, nullptr, monitor_info.rcMonitor.left, monitor_info.rcMonitor.top,
                    monitor_info.rcMonitor.right - monitor_info.rcMonitor.left,
                    monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top,
                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
@@ -350,7 +350,7 @@ public:
       SetWindowLong(win.m_hwnd, GWL_STYLE, win.m_fsStyle);
       SetWindowLong(win.m_hwnd, GWL_EXSTYLE, win.m_fsExStyle);
 
-      SetWindowPos(win.m_hwnd, NULL, win.m_fsRect.left, win.m_fsRect.top, win.m_fsRect.right - win.m_fsRect.left,
+      SetWindowPos(win.m_hwnd, nullptr, win.m_fsRect.left, win.m_fsRect.top, win.m_fsRect.right - win.m_fsRect.left,
                    win.m_fsRect.bottom - win.m_fsRect.top, SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
 
       win.m_fs = false;
@@ -372,8 +372,8 @@ public:
     });
 
     /* Pump messages */
-    MSG msg = {0};
-    while (GetMessage(&msg, NULL, 0, 0)) {
+    MSG msg = {};
+    while (GetMessage(&msg, nullptr, 0, 0)) {
       if (!msg.hwnd) {
         /* PostThreadMessage events */
         switch (msg.message) {
@@ -457,7 +457,7 @@ public:
   }
 };
 
-IApplication* APP = NULL;
+IApplication* APP = nullptr;
 int ApplicationRun(IApplication::EPlatformType platform, IApplicationCallback& cb, SystemStringView uniqueName,
                    SystemStringView friendlyName, SystemStringView pname, const std::vector<SystemString>& args,
                    std::string_view gfxApi, uint32_t samples, uint32_t anisotropy, bool deepColor,
@@ -484,7 +484,7 @@ int ApplicationRun(IApplication::EPlatformType platform, IApplicationCallback& c
   WIN32_CURSORS.m_wait = LoadCursor(nullptr, IDC_WAIT);
 
   /* One class for *all* boo windows */
-  WNDCLASS wndClass = {0, WindowProc, 0, 0, GetModuleHandle(nullptr), 0, 0, 0, 0, L"BooWindow"};
+  WNDCLASS wndClass = {0, WindowProc, 0, 0, GetModuleHandle(nullptr), nullptr, nullptr, nullptr, nullptr, L"BooWindow"};
   wndClass.hIcon = LoadIconW(wndClass.hInstance, MAKEINTRESOURCEW(101));
   wndClass.hCursor = WIN32_CURSORS.m_arrow;
   RegisterClassW(&wndClass);

--- a/lib/win/ApplicationWin32.cpp
+++ b/lib/win/ApplicationWin32.cpp
@@ -110,8 +110,8 @@ public:
     if (!dxgilib)
       Log.report(logvisor::Fatal, fmt("unable to load dxgi.dll"));
 
-    typedef HRESULT(WINAPI * CreateDXGIFactory1PROC)(REFIID riid, _COM_Outptr_ void** ppFactory);
-    CreateDXGIFactory1PROC MyCreateDXGIFactory1 = (CreateDXGIFactory1PROC)GetProcAddress(dxgilib, "CreateDXGIFactory1");
+    using CreateDXGIFactory1PROC =  HRESULT(WINAPI*)(REFIID riid, _COM_Outptr_ void** ppFactory);
+    auto MyCreateDXGIFactory1 = (CreateDXGIFactory1PROC)GetProcAddress(dxgilib, "CreateDXGIFactory1");
     if (!MyCreateDXGIFactory1)
       Log.report(logvisor::Fatal, fmt("unable to find CreateDXGIFactory1 in DXGI.dll\n"));
 

--- a/lib/win/Win32Common.hpp
+++ b/lib/win/Win32Common.hpp
@@ -26,7 +26,7 @@ extern PFN_GetScaleFactorForMonitor MyGetScaleFactorForMonitor;
 
 struct OGLContext {
   ComPtr<IDXGIFactory1> m_dxFactory;
-  HGLRC m_lastContext = 0;
+  HGLRC m_lastContext = nullptr;
   struct Window {
     HWND m_hwnd;
     HDC m_deviceContext;

--- a/lib/win/Win32Common.hpp
+++ b/lib/win/Win32Common.hpp
@@ -20,7 +20,7 @@ extern std::condition_variable g_nwcv;
 
 #if _WIN32_WINNT_WINBLUE && !WINDOWS_STORE
 #include <ShellScalingApi.h>
-typedef HRESULT(WINAPI* PFN_GetScaleFactorForMonitor)(_In_ HMONITOR, _Out_ DEVICE_SCALE_FACTOR*);
+using PFN_GetScaleFactorForMonitor = HRESULT(WINAPI*)(_In_ HMONITOR, _Out_ DEVICE_SCALE_FACTOR*);
 extern PFN_GetScaleFactorForMonitor MyGetScaleFactorForMonitor;
 #endif
 

--- a/lib/win/WinCommon.hpp
+++ b/lib/win/WinCommon.hpp
@@ -25,8 +25,8 @@ class IWindow;
 
 #include <d3d9.h>
 
-typedef int (WINAPI *pD3DPERF_BeginEvent)(D3DCOLOR col, LPCWSTR wszName);
-typedef int (WINAPI *pD3DPERF_EndEvent)();
+using pD3DPERF_BeginEvent = int (WINAPI*)(D3DCOLOR col, LPCWSTR wszName);
+using pD3DPERF_EndEvent = int (WINAPI*)();
 
 struct D3D12Context {
   ComPtr<IDXGIFactory2> m_dxFactory;

--- a/lib/win/WindowWin32.cpp
+++ b/lib/win/WindowWin32.cpp
@@ -198,7 +198,7 @@ public:
         Log.report(logvisor::Fatal, fmt("glewInit failed"));
       wglCreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC)wglGetProcAddress("wglCreateContextAttribsARB");
       wglChoosePixelFormatARB = (PFNWGLCHOOSEPIXELFORMATARBPROC)wglGetProcAddress("wglChoosePixelFormatARB");
-      wglMakeCurrent(w.m_deviceContext, 0);
+      wglMakeCurrent(w.m_deviceContext, nullptr);
       wglDeleteContext(tmpCtx);
 
       if (b3dCtx.m_ctxOgl.m_glCtx.m_deepColor) {
@@ -303,7 +303,7 @@ public:
   IGraphicsDataFactory* getDataFactory() override { return m_dataFactory.get(); }
 
   /* Creates a new context on current thread!! Call from client loading thread */
-  HGLRC m_mainCtx = 0;
+  HGLRC m_mainCtx = nullptr;
   IGraphicsDataFactory* getMainContextDataFactory() override {
     OGLContext::Window& w = m_3dCtx.m_ctxOgl.m_windows[m_parentWindow];
     if (!m_mainCtx) {
@@ -317,7 +317,7 @@ public:
   }
 
   /* Creates a new context on current thread!! Call from client loading thread */
-  HGLRC m_loadCtx = 0;
+  HGLRC m_loadCtx = nullptr;
   IGraphicsDataFactory* getLoadContextDataFactory() override {
     OGLContext::Window& w = m_3dCtx.m_ctxOgl.m_windows[m_parentWindow];
     if (!m_loadCtx) {
@@ -852,7 +852,7 @@ public:
     AdjustWindowRect(&r, WS_OVERLAPPEDWINDOW, FALSE);
 
     m_hwnd = CreateWindowW(L"BooWindow", title.data(), WS_OVERLAPPEDWINDOW, r.left, r.top, r.right - r.left,
-                           r.bottom - r.top, NULL, NULL, NULL, NULL);
+                           r.bottom - r.top, nullptr, nullptr, nullptr, nullptr);
     HINSTANCE wndInstance = HINSTANCE(GetWindowLongPtr(m_hwnd, GWLP_HINSTANCE));
     m_imc = ImmGetContext(m_hwnd);
 

--- a/lib/x11/ApplicationUnix.cpp
+++ b/lib/x11/ApplicationUnix.cpp
@@ -99,8 +99,8 @@ DBusConnection* RegisterDBus(const char* appName, bool& isFirst) {
     fmt::print(stderr, fmt("DBus Connection Error ({})\n"), err.message);
     dbus_error_free(&err);
   }
-  if (NULL == conn)
-    return NULL;
+  if (conn == nullptr)
+    return nullptr;
 
   /* request our name on the bus and check for errors */
   int ret = dbus_bus_request_name(conn, fmt::format(fmt("boo.{}.unique"), appName).c_str(),
@@ -109,7 +109,7 @@ DBusConnection* RegisterDBus(const char* appName, bool& isFirst) {
     fmt::print(stderr, fmt("DBus Name Error ({})\n"), err.message);
     dbus_error_free(&err);
     dbus_connection_close(conn);
-    return NULL;
+    return nullptr;
   }
   if (DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER != ret)
     isFirst = false;

--- a/lib/x11/ApplicationXlib.hpp
+++ b/lib/x11/ApplicationXlib.hpp
@@ -459,7 +459,7 @@ public:
       FD_ZERO(&fds);
       FD_SET(m_x11Fd, &fds);
       FD_SET(m_dbusFd, &fds);
-      if (pselect(m_maxFd + 1, &fds, NULL, NULL, NULL, &origmask) < 0) {
+      if (pselect(m_maxFd + 1, &fds, nullptr, nullptr, nullptr, &origmask) < 0) {
         /* SIGINT/SIGUSR2 handled here */
         if (errno == EINTR)
           break;

--- a/lib/x11/WindowXlib.cpp
+++ b/lib/x11/WindowXlib.cpp
@@ -59,7 +59,7 @@
 #undef False
 #undef True
 
-typedef GLXContext (*glXCreateContextAttribsARBProc)(Display*, GLXFBConfig, GLXContext, Bool, const int*);
+using glXCreateContextAttribsARBProc = GLXContext (*)(Display*, GLXFBConfig, GLXContext, Bool, const int*);
 static glXCreateContextAttribsARBProc glXCreateContextAttribsARB = 0;
 static bool s_glxError;
 static int ctxErrorHandler(Display* dpy, XErrorEvent* ev) {

--- a/lib/x11/WindowXlib.cpp
+++ b/lib/x11/WindowXlib.cpp
@@ -227,7 +227,7 @@ struct XlibAtoms {
     m_imagePng = XInternAtom(disp, "image/png", false);
   }
 };
-static XlibAtoms* S_ATOMS = NULL;
+static XlibAtoms* S_ATOMS = nullptr;
 
 static Atom GetClipboardTypeAtom(EClipboardType t) {
   switch (t) {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -13,13 +13,13 @@
 namespace boo {
 
 class DolphinSmashAdapterCallback : public IDolphinSmashAdapterCallback {
-  void controllerConnected(unsigned idx, EDolphinControllerType) {
+  void controllerConnected(unsigned idx, EDolphinControllerType) override {
     //        printf("CONTROLLER %u CONNECTED\n", idx);
   }
-  void controllerDisconnected(unsigned idx) {
+  void controllerDisconnected(unsigned idx) override {
     //        printf("CONTROLLER %u DISCONNECTED\n", idx);
   }
-  void controllerUpdate(unsigned idx, EDolphinControllerType, const DolphinControllerState& state) {
+  void controllerUpdate(unsigned idx, EDolphinControllerType, const DolphinControllerState& state) override {
     //        printf("CONTROLLER %u UPDATE %d %d\n", idx, state.m_leftStick[0], state.m_leftStick[1]);
     //        printf("                     %d %d\n", state.m_rightStick[0], state.m_rightStick[1]);
     //        printf("                     %d %d\n", state.m_analogTriggers[0], state.m_analogTriggers[1]);
@@ -27,8 +27,8 @@ class DolphinSmashAdapterCallback : public IDolphinSmashAdapterCallback {
 };
 
 class DualshockPadCallback : public IDualshockPadCallback {
-  void controllerDisconnected() { printf("CONTROLLER DISCONNECTED\n"); }
-  void controllerUpdate(DualshockPad& pad, const DualshockPadState& state) {
+  void controllerDisconnected() override { printf("CONTROLLER DISCONNECTED\n"); }
+  void controllerUpdate(DualshockPad& pad, const DualshockPadState& state) override {
     static time_t timeTotal;
     static time_t lastTime = 0;
     timeTotal = time(NULL);
@@ -63,9 +63,9 @@ class DualshockPadCallback : public IDualshockPadCallback {
 };
 
 class GenericPadCallback : public IGenericPadCallback {
-  void controllerConnected() { printf("CONTROLLER CONNECTED\n"); }
-  void controllerDisconnected() { printf("CONTROLLER DISCONNECTED\n"); }
-  void valueUpdate(const HIDMainItem& item, int32_t value) {
+  void controllerConnected() override { printf("CONTROLLER CONNECTED\n"); }
+  void controllerDisconnected() override { printf("CONTROLLER DISCONNECTED\n"); }
+  void valueUpdate(const HIDMainItem& item, int32_t value) override {
     const char* pageName = item.GetUsagePageName();
     const char* usageName = item.GetUsageName();
     if (pageName) {
@@ -83,8 +83,8 @@ class GenericPadCallback : public IGenericPadCallback {
 };
 
 class NintendoPowerACallback : public INintendoPowerACallback {
-  void controllerDisconnected() { fprintf(stderr, "CONTROLLER DISCONNECTED\n"); }
-  void controllerUpdate(const NintendoPowerAState& state) {
+  void controllerDisconnected() override { fprintf(stderr, "CONTROLLER DISCONNECTED\n"); }
+  void controllerUpdate(const NintendoPowerAState& state) override {
     fprintf(stderr,
             "%i %i\n"
             "%i %i\n",
@@ -105,7 +105,7 @@ class TestDeviceFinder : public DeviceFinder {
 public:
   TestDeviceFinder()
   : DeviceFinder({dev_typeid(DolphinSmashAdapter), dev_typeid(NintendoPowerA), dev_typeid(GenericPad)}) {}
-  void deviceConnected(DeviceToken& tok) {
+  void deviceConnected(DeviceToken& tok) override {
     auto dev = tok.openAndGetDevice();
     if (!dev)
       return;
@@ -125,7 +125,7 @@ public:
       m_generic->setCallback(&m_genericCb);
     }
   }
-  void deviceDisconnected(DeviceToken&, DeviceBase* device) {
+  void deviceDisconnected(DeviceToken&, DeviceBase* device) override {
     if (m_smashAdapter.get() == device)
       m_smashAdapter.reset();
     if (m_ds3.get() == device)
@@ -143,55 +143,55 @@ struct CTestWindowCallback : IWindowCallback {
   bool m_rectDirty = false;
   bool m_windowInvalid = false;
 
-  void resized(const SWindowRect& rect, bool sync) {
+  void resized(const SWindowRect& rect, bool sync) override {
     m_lastRect = rect;
     m_rectDirty = true;
     fprintf(stderr, "Resized %d, %d (%d, %d)\n", rect.size[0], rect.size[1], rect.location[0], rect.location[1]);
   }
 
-  void mouseDown(const SWindowCoord& coord, EMouseButton button, EModifierKey mods) {
+  void mouseDown(const SWindowCoord& coord, EMouseButton button, EModifierKey mods) override {
     fprintf(stderr, "Mouse Down %d (%f,%f)\n", int(button), coord.norm[0], coord.norm[1]);
   }
-  void mouseUp(const SWindowCoord& coord, EMouseButton button, EModifierKey mods) {
+  void mouseUp(const SWindowCoord& coord, EMouseButton button, EModifierKey mods) override {
     fprintf(stderr, "Mouse Up %d (%f,%f)\n", int(button), coord.norm[0], coord.norm[1]);
   }
-  void mouseMove(const SWindowCoord& coord) {
+  void mouseMove(const SWindowCoord& coord) override {
     // fprintf(stderr, "Mouse Move (%f,%f)\n", coord.norm[0], coord.norm[1]);
   }
-  void mouseEnter(const SWindowCoord& coord) {
+  void mouseEnter(const SWindowCoord& coord) override {
     fprintf(stderr, "Mouse entered (%f,%f)\n", coord.norm[0], coord.norm[1]);
   }
-  void mouseLeave(const SWindowCoord& coord) { fprintf(stderr, "Mouse left (%f,%f)\n", coord.norm[0], coord.norm[1]); }
-  void scroll(const SWindowCoord& coord, const SScrollDelta& scroll) {
+  void mouseLeave(const SWindowCoord& coord) override { fprintf(stderr, "Mouse left (%f,%f)\n", coord.norm[0], coord.norm[1]); }
+  void scroll(const SWindowCoord& coord, const SScrollDelta& scroll) override {
     // fprintf(stderr, "Mouse Scroll (%f,%f) (%f,%f)\n", coord.norm[0], coord.norm[1], scroll.delta[0],
     // scroll.delta[1]);
   }
 
-  void touchDown(const STouchCoord& coord, uintptr_t tid) {
+  void touchDown(const STouchCoord& coord, uintptr_t tid) override {
     // fprintf(stderr, "Touch Down %16lX (%f,%f)\n", tid, coord.coord[0], coord.coord[1]);
   }
-  void touchUp(const STouchCoord& coord, uintptr_t tid) {
+  void touchUp(const STouchCoord& coord, uintptr_t tid) override {
     // fprintf(stderr, "Touch Up %16lX (%f,%f)\n", tid, coord.coord[0], coord.coord[1]);
   }
-  void touchMove(const STouchCoord& coord, uintptr_t tid) {
+  void touchMove(const STouchCoord& coord, uintptr_t tid) override {
     // fprintf(stderr, "Touch Move %16lX (%f,%f)\n", tid, coord.coord[0], coord.coord[1]);
   }
 
-  void charKeyDown(unsigned long charCode, EModifierKey mods, bool isRepeat) {}
-  void charKeyUp(unsigned long charCode, EModifierKey mods) {}
-  void specialKeyDown(ESpecialKey key, EModifierKey mods, bool isRepeat) {
+  void charKeyDown(unsigned long charCode, EModifierKey mods, bool isRepeat) override {}
+  void charKeyUp(unsigned long charCode, EModifierKey mods) override {}
+  void specialKeyDown(ESpecialKey key, EModifierKey mods, bool isRepeat) override {
     if (key == ESpecialKey::Enter && True(mods & EModifierKey::Alt))
       m_fullscreenToggleRequested = true;
   }
-  void specialKeyUp(ESpecialKey key, EModifierKey mods) {}
-  void modKeyDown(EModifierKey mod, bool isRepeat) {}
-  void modKeyUp(EModifierKey mod) {}
+  void specialKeyUp(ESpecialKey key, EModifierKey mods) override {}
+  void modKeyDown(EModifierKey mod, bool isRepeat) override {}
+  void modKeyUp(EModifierKey mod) override {}
 
-  void windowMoved(const SWindowRect& rect) {
+  void windowMoved(const SWindowRect& rect) override {
     // fprintf(stderr, "Moved %d, %d (%d, %d)\n", rect.size[0], rect.size[1], rect.location[0], rect.location[1]);
   }
 
-  void destroyed() { m_windowInvalid = true; }
+  void destroyed() override { m_windowInvalid = true; }
 };
 
 struct TestApplicationCallback : IApplicationCallback {
@@ -389,7 +389,7 @@ struct TestApplicationCallback : IApplicationCallback {
     } BooTrace);
   }
 
-  int appMain(IApplication* app) {
+  int appMain(IApplication* app) override {
     mainWindow = app->newWindow(_SYS_STR("YAY!"));
     mainWindow->setCallback(&windowCallback);
     mainWindow->showWindow();
@@ -455,8 +455,8 @@ struct TestApplicationCallback : IApplicationCallback {
     m_binding.reset();
     return 0;
   }
-  void appQuitting(IApplication*) { running = false; }
-  void appFilesOpen(IApplication*, const std::vector<SystemString>& paths) {
+  void appQuitting(IApplication*) override { running = false; }
+  void appFilesOpen(IApplication*, const std::vector<SystemString>& paths) override {
     fprintf(stderr, "OPENING: ");
     for (const SystemString& path : paths) {
 #if _WIN32


### PR DESCRIPTION
Makes member functions const where applicable, given they don't modify member state. I noticed I also missed a few override specifiers for platform-specific input-related code, so I added those. While in the area as well, we can convert usages of `NULL` over to `nullptr` where applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/18)
<!-- Reviewable:end -->
