### PR TITLE
DeviceToken: Amend move constructor

### DIFF
--- a/include/boo/inputdev/DeviceToken.hpp
+++ b/include/boo/inputdev/DeviceToken.hpp
@@ -28,14 +28,7 @@ class DeviceToken {
 
 public:
   DeviceToken(const DeviceToken&) = delete;
-  DeviceToken(const DeviceToken&& other)
-  : m_devType(other.m_devType)
-  , m_vendorId(other.m_vendorId)
-  , m_productId(other.m_productId)
-  , m_vendorName(other.m_vendorName)
-  , m_productName(other.m_productName)
-  , m_devPath(other.m_devPath)
-  , m_connectedDev(other.m_connectedDev) {}
+  DeviceToken(DeviceToken&& other) noexcept = default;
   DeviceToken(DeviceType devType, unsigned vid, unsigned pid, const char* vname, const char* pname, const char* path)
   : m_devType(devType), m_vendorId(vid), m_productId(pid), m_devPath(path), m_connectedDev(NULL) {
     if (vname)
@@ -43,6 +36,12 @@ public:
     if (pname)
       m_productName = pname;
   }
+
+  DeviceToken& operator=(const DeviceToken&) = delete;
+  DeviceToken& operator=(DeviceToken&&) noexcept = default;
+
+  bool operator==(const DeviceToken& rhs) const { return m_devPath == rhs.m_devPath; }
+  bool operator<(const DeviceToken& rhs) const { return m_devPath < rhs.m_devPath; }
 
   DeviceType getDeviceType() const { return m_devType; }
   unsigned getVendorId() const { return m_vendorId; }
@@ -56,9 +55,6 @@ public:
       m_connectedDev = DeviceSignature::DeviceNew(*this);
     return m_connectedDev;
   }
-
-  bool operator==(const DeviceToken& rhs) const { return m_devPath == rhs.m_devPath; }
-  bool operator<(const DeviceToken& rhs) const { return m_devPath < rhs.m_devPath; }
 };
 
 } // namespace boo

--- a/lib/audiodev/PulseAudio.cpp
+++ b/lib/audiodev/PulseAudio.cpp
@@ -270,7 +270,7 @@ struct PulseAudioVoiceEngine : LinuxMidi {
     if (i)
       userdata->m_sinks.push_back(std::make_pair(i->name, i->description));
   }
-  std::vector<std::pair<std::string, std::string>> enumerateAudioOutputs() const {
+  std::vector<std::pair<std::string, std::string>> enumerateAudioOutputs() const override {
     pa_operation* op = pa_context_get_sink_info_list(m_ctx, pa_sink_info_cb_t(_getSinkInfoListReply), (void*)this);
     _paIterate(op);
     pa_operation_unref(op);

--- a/lib/x11/WindowXlib.cpp
+++ b/lib/x11/WindowXlib.cpp
@@ -510,7 +510,7 @@ public:
     visualIdOut = screen->root_visual->visualid;
   }
 
-  void destroy() {
+  void destroy() override {
     VulkanContext::Window& m_windowCtx = *m_ctx->m_windows[m_parentWindow];
     m_windowCtx.m_swapChains[0].destroy(m_ctx->m_dev);
     m_windowCtx.m_swapChains[1].destroy(m_ctx->m_dev);


### PR DESCRIPTION
The default move constructor isn't const qualified. The copy assignment operator wasn't deleted either which is somewhat dangerous. We can also opt for simply defaulting the move constructor and assignment operators instead of defining the move constructor like a copy constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/19)
<!-- Reviewable:end -->
