### PR TITLE
BooObject: Make ObjToken interface noexcept where applicable

### DIFF
--- a/include/boo/BooObject.hpp
+++ b/include/boo/BooObject.hpp
@@ -14,9 +14,10 @@ protected:
 
 public:
   virtual std::unique_lock<std::recursive_mutex> destructorLock() = 0;
-  void increment() { m_refCount++; }
+  void increment() { m_refCount.fetch_add(1, std::memory_order_relaxed); }
   void decrement() {
-    if (m_refCount.fetch_sub(1) == 1) {
+    if (m_refCount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      std::atomic_thread_fence(std::memory_order_acquire);
       auto lk = destructorLock();
       delete this;
     }

--- a/include/boo/BooObject.hpp
+++ b/include/boo/BooObject.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
-#include "nxstl/mutex"
 
 namespace boo {
 
@@ -13,12 +11,10 @@ protected:
   virtual ~IObj() = default;
 
 public:
-  virtual std::unique_lock<std::recursive_mutex> destructorLock() = 0;
   void increment() { m_refCount.fetch_add(1, std::memory_order_relaxed); }
   void decrement() {
-    if (m_refCount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    if (m_refCount.fetch_sub(1, std::memory_order_release) == 1) {
       std::atomic_thread_fence(std::memory_order_acquire);
-      auto lk = destructorLock();
       delete this;
     }
   }

--- a/include/boo/BooObject.hpp
+++ b/include/boo/BooObject.hpp
@@ -11,8 +11,8 @@ protected:
   virtual ~IObj() = default;
 
 public:
-  void increment() { m_refCount.fetch_add(1, std::memory_order_relaxed); }
-  void decrement() {
+  void increment() noexcept { m_refCount.fetch_add(1, std::memory_order_relaxed); }
+  void decrement() noexcept {
     if (m_refCount.fetch_sub(1, std::memory_order_release) == 1) {
       std::atomic_thread_fence(std::memory_order_acquire);
       delete this;
@@ -25,17 +25,17 @@ class ObjToken {
   SubCls* m_obj = nullptr;
 
 public:
-  ObjToken() = default;
-  ObjToken(SubCls* obj) : m_obj(obj) {
+  ObjToken() noexcept = default;
+  ObjToken(SubCls* obj) noexcept : m_obj(obj) {
     if (m_obj)
       m_obj->increment();
   }
-  ObjToken(const ObjToken& other) : m_obj(other.m_obj) {
+  ObjToken(const ObjToken& other) noexcept : m_obj(other.m_obj) {
     if (m_obj)
       m_obj->increment();
   }
-  ObjToken(ObjToken&& other) : m_obj(other.m_obj) { other.m_obj = nullptr; }
-  ObjToken& operator=(SubCls* obj) {
+  ObjToken(ObjToken&& other) noexcept : m_obj(other.m_obj) { other.m_obj = nullptr; }
+  ObjToken& operator=(SubCls* obj) noexcept {
     if (m_obj)
       m_obj->decrement();
     m_obj = obj;
@@ -43,7 +43,7 @@ public:
       m_obj->increment();
     return *this;
   }
-  ObjToken& operator=(const ObjToken& other) {
+  ObjToken& operator=(const ObjToken& other) noexcept {
     if (m_obj)
       m_obj->decrement();
     m_obj = other.m_obj;
@@ -51,26 +51,26 @@ public:
       m_obj->increment();
     return *this;
   }
-  ObjToken& operator=(ObjToken&& other) {
+  ObjToken& operator=(ObjToken&& other) noexcept {
     if (m_obj)
       m_obj->decrement();
     m_obj = other.m_obj;
     other.m_obj = nullptr;
     return *this;
   }
-  ~ObjToken() {
+  ~ObjToken() noexcept {
     if (m_obj)
       m_obj->decrement();
   }
-  SubCls* get() const { return m_obj; }
-  SubCls* operator->() const { return m_obj; }
-  SubCls& operator*() const { return *m_obj; }
+  SubCls* get() const noexcept { return m_obj; }
+  SubCls* operator->() const noexcept { return m_obj; }
+  SubCls& operator*() const noexcept { return *m_obj; }
   template <class T>
-  T* cast() const {
+  T* cast() const noexcept {
     return static_cast<T*>(m_obj);
   }
-  operator bool() const { return m_obj != nullptr; }
-  void reset() {
+  operator bool() const noexcept { return m_obj != nullptr; }
+  void reset() noexcept {
     if (m_obj)
       m_obj->decrement();
     m_obj = nullptr;

--- a/lib/audiodev/AQS.cpp
+++ b/lib/audiodev/AQS.cpp
@@ -1,5 +1,4 @@
 #include "AudioVoiceEngine.hpp"
-#include "logvisor/logvisor.hpp"
 #include "boo/IApplication.hpp"
 #include "../CFPointer.hpp"
 
@@ -7,8 +6,7 @@
 #include <CoreMIDI/CoreMIDI.h>
 #include <CoreAudio/HostTime.h>
 
-#include <mutex>
-#include <condition_variable>
+#include <logvisor/logvisor.hpp>
 
 namespace boo {
 static logvisor::Module Log("boo::AQS");

--- a/lib/audiodev/AudioSubmix.cpp
+++ b/lib/audiodev/AudioSubmix.cpp
@@ -21,9 +21,6 @@ AudioSubmix*& AudioSubmix::_getHeadPtr(BaseAudioVoiceEngine* head) { return head
 std::unique_lock<std::recursive_mutex> AudioSubmix::_getHeadLock(BaseAudioVoiceEngine* head) {
   return std::unique_lock<std::recursive_mutex>{head->m_dataMutex};
 }
-std::unique_lock<std::recursive_mutex> AudioSubmix::destructorLock() {
-  return std::unique_lock<std::recursive_mutex>{m_head->m_dataMutex};
-}
 
 bool AudioSubmix::_isDirectDependencyOf(AudioSubmix* send) { return m_sendGains.find(send) != m_sendGains.cend(); }
 

--- a/lib/audiodev/AudioSubmix.hpp
+++ b/lib/audiodev/AudioSubmix.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "boo/audiodev/IAudioSubmix.hpp"
-#include <list>
-#include <vector>
 #include <array>
+#include <list>
+#include <mutex>
 #include <unordered_map>
+#include <vector>
 #include "Common.hpp"
 
 #if __SSE__
@@ -80,7 +81,6 @@ class AudioSubmix : public ListNode<AudioSubmix, BaseAudioVoiceEngine*, IAudioSu
 public:
   static AudioSubmix*& _getHeadPtr(BaseAudioVoiceEngine* head);
   static std::unique_lock<std::recursive_mutex> _getHeadLock(BaseAudioVoiceEngine* head);
-  std::unique_lock<std::recursive_mutex> destructorLock() override;
 
   AudioSubmix(BaseAudioVoiceEngine& root, IAudioSubmixCallback* cb, int busId, bool mainOut);
   ~AudioSubmix() override;

--- a/lib/audiodev/AudioVoice.cpp
+++ b/lib/audiodev/AudioVoice.cpp
@@ -18,9 +18,6 @@ AudioVoice*& AudioVoice::_getHeadPtr(BaseAudioVoiceEngine* head) { return head->
 std::unique_lock<std::recursive_mutex> AudioVoice::_getHeadLock(BaseAudioVoiceEngine* head) {
   return std::unique_lock<std::recursive_mutex>{head->m_dataMutex};
 }
-std::unique_lock<std::recursive_mutex> AudioVoice::destructorLock() {
-  return std::unique_lock<std::recursive_mutex>{m_head->m_dataMutex};
-}
 
 void AudioVoice::_setPitchRatio(double ratio, bool slew) {
   if (m_dynamicRate) {

--- a/lib/audiodev/AudioVoice.hpp
+++ b/lib/audiodev/AudioVoice.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <soxr.h>
-#include <list>
+#include <mutex>
 #include <unordered_map>
 #include "boo/audiodev/IAudioVoice.hpp"
 #include "AudioMatrix.hpp"
-#include "Common.hpp"
 #include "AudioVoiceEngine.hpp"
+#include "Common.hpp"
 
 struct AudioUnitVoiceEngine;
 struct VSTVoiceEngine;
@@ -64,7 +64,6 @@ protected:
 public:
   static AudioVoice*& _getHeadPtr(BaseAudioVoiceEngine* head);
   static std::unique_lock<std::recursive_mutex> _getHeadLock(BaseAudioVoiceEngine* head);
-  std::unique_lock<std::recursive_mutex> destructorLock() override;
 
   ~AudioVoice() override;
   void resetSampleRate(double sampleRate) override;

--- a/lib/graphicsdev/D3D11.cpp
+++ b/lib/graphicsdev/D3D11.cpp
@@ -1,18 +1,20 @@
 #include "../win/Win32Common.hpp"
-#include "logvisor/logvisor.hpp"
 #include "boo/graphicsdev/D3D.hpp"
 #include "boo/IGraphicsContext.hpp"
 #include "Common.hpp"
-#include <vector>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
-#include <d3dcompiler.h>
-#include <comdef.h>
+
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <forward_list>
-#include "xxhash/xxhash.h"
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <d3dcompiler.h>
+#include <comdef.h>
+
+#include <logvisor/logvisor.hpp>
 
 #undef min
 #undef max

--- a/lib/graphicsdev/GL.cpp
+++ b/lib/graphicsdev/GL.cpp
@@ -2,21 +2,21 @@
 #include "boo/graphicsdev/glew.h"
 #include "boo/IApplication.hpp"
 #include "Common.hpp"
-#include <thread>
-#include <condition_variable>
+
 #include <array>
-#include <unordered_map>
-#include <unordered_set>
-#include "xxhash/xxhash.h"
-#include "glslang/Public/ShaderLang.h"
-#include "glslang/Include/Types.h"
-#include "StandAlone/ResourceLimits.h"
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <glslang/Public/ShaderLang.h>
+#include <glslang/Include/Types.h>
+#include <StandAlone/ResourceLimits.h>
+
+#include <logvisor/logvisor.hpp>
 
 #if _WIN32
 #include "../win/WinCommon.hpp"
 #endif
-
-#include "logvisor/logvisor.hpp"
 
 #undef min
 #undef max

--- a/lib/graphicsdev/Vulkan.cpp
+++ b/lib/graphicsdev/Vulkan.cpp
@@ -1060,9 +1060,6 @@ struct VulkanDescriptorPool : ListNode<VulkanDescriptorPool, VulkanDataFactoryIm
 
   ~VulkanDescriptorPool() { vk::DestroyDescriptorPool(m_head->m_ctx->m_dev, m_descPool, nullptr); }
 
-  std::unique_lock<std::recursive_mutex> destructorLock() override {
-    return std::unique_lock<std::recursive_mutex>{m_head->m_dataMutex};
-  }
   static std::unique_lock<std::recursive_mutex> _getHeadLock(VulkanDataFactoryImpl* factory) {
     return std::unique_lock<std::recursive_mutex>{factory->m_dataMutex};
   }

--- a/lib/inputdev/HIDDeviceWinUSB.cpp
+++ b/lib/inputdev/HIDDeviceWinUSB.cpp
@@ -2,12 +2,13 @@
 #include "IHIDDevice.hpp"
 #include "boo/inputdev/DeviceToken.hpp"
 #include "boo/inputdev/DeviceBase.hpp"
-#include <thread>
-#include <mutex>
-#include <condition_variable>
-#include <cstring>
-#include <cstdio>
+
 #include <algorithm>
+#include <condition_variable>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <thread>
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1

--- a/lib/mac/WindowCocoa.mm
+++ b/lib/mac/WindowCocoa.mm
@@ -1,12 +1,19 @@
 #include "boo/graphicsdev/Metal.hpp"
 #include "CocoaCommon.hpp"
+
+#include "boo/IApplication.hpp"
+#include "boo/IGraphicsContext.hpp"
+#include "boo/IWindow.hpp"
+#include "boo/audiodev/IAudioVoiceEngine.hpp"
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
 #import <AppKit/AppKit.h>
 #import <CoreVideo/CVDisplayLink.h>
-#include "boo/IApplication.hpp"
-#include "boo/IWindow.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include "boo/audiodev/IAudioVoiceEngine.hpp"
-#include "logvisor/logvisor.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 #if !__has_feature(objc_arc)
 #error ARC Required

--- a/lib/nx/ApplicationNX.cpp
+++ b/lib/nx/ApplicationNX.cpp
@@ -1,9 +1,13 @@
-#include "boo/IApplication.hpp"
-#include "logvisor/logvisor.hpp"
 #include "nxstl/thread"
 #include "nxstl/condition_variable"
+#include "nxstl/mutex"
+
+#include "boo/IApplication.hpp"
 #include "boo/graphicsdev/NX.hpp"
-#include <limits.h>
+
+#include <climits>
+
+#include <logvisor/logvisor.hpp>
 
 #include <switch.h>
 

--- a/lib/win/ApplicationWin32.cpp
+++ b/lib/win/ApplicationWin32.cpp
@@ -25,6 +25,9 @@ PFN_GetScaleFactorForMonitor MyGetScaleFactorForMonitor = nullptr;
 #include "boo/graphicsdev/Vulkan.hpp"
 #endif
 
+#include <condition_variable>
+#include <mutex>
+
 DWORD g_mainThreadId = 0;
 std::mutex g_nwmt;
 std::condition_variable g_nwcv;

--- a/lib/win/Win32Common.hpp
+++ b/lib/win/Win32Common.hpp
@@ -14,6 +14,9 @@
 #endif
 #include "boo/graphicsdev/GL.hpp"
 
+#include <condition_variable>
+#include <mutex>
+
 extern DWORD g_mainThreadId;
 extern std::mutex g_nwmt;
 extern std::condition_variable g_nwcv;

--- a/lib/x11/ApplicationXlib.hpp
+++ b/lib/x11/ApplicationXlib.hpp
@@ -12,16 +12,16 @@
 #include <X11/extensions/XInput2.h>
 #include <GL/glx.h>
 #include <GL/glxext.h>
-#include <locale>
 
 #include <dbus/dbus.h>
 DBusConnection* RegisterDBus(const char* appName, bool& isFirst);
 
-#include <signal.h>
+#include <condition_variable>
+#include <csignal>
+#include <locale>
+#include <mutex>
 #include <sys/param.h>
 #include <thread>
-#include <mutex>
-#include <condition_variable>
 
 #include "XlibCommon.hpp"
 #include <X11/cursorfont.h>

--- a/lib/x11/WindowXlib.cpp
+++ b/lib/x11/WindowXlib.cpp
@@ -11,16 +11,16 @@
 #include <X11/Xlib-xcb.h>
 #endif
 
-#include <limits.h>
-#include <unistd.h>
-#include <cstdlib>
-#include <cstdio>
+#include <climits>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <memory>
+#include <string>
+#include <unordered_set>
 
-#include <thread>
-#include <mutex>
-#include <condition_variable>
+#include <unistd.h>
 
 #include <GL/glx.h>
 
@@ -32,7 +32,7 @@
 #include <X11/extensions/XInput2.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/Xrandr.h>
-#include "logvisor/logvisor.hpp"
+#include <logvisor/logvisor.hpp>
 
 #include "XlibCommon.hpp"
 


### PR DESCRIPTION
Increasing a reference count is able to always be relaxed. New references to an object can only be formed from an existing reference. The passing of an existing reference from one thread to another will
already necessitate the use of synchronization primitives, so this is a safe change to make. Regardless, nothing other than the object itself directly relies on the reference count, so this will always be a
suitably atomic operation, even in the face of no synchronization primitives.

In the case of decrementing the reference count, it's sufficient to treat it with release semantics and follow it up with an atomic thread fence. This ensures that all accesses to the object in one thread will occur before the delete occurs in another thread (if the situation ever occurs).

This also allows making the move constructor and assignment operators of ObjToken noexcept (and the rest of its trivial interface). This makes it play nicer with standard containers, as they use `std::move_if_noexcept` internally. For move constructors/assignment operators that aren't noexcept, this would result in copies occurring, as a move wouldn't be able to occur. This would result in reference count increment/decrement churn if any reallocations were needed internally within the standard containers. Now, moves can be done instead, avoiding the churn.

This also tidies up the standard inclusions where necessary to avoid indirect includes, and alphabetizes them to make them nicer to read.

This was tested with tsan on macOS and seems to have no issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/20)
<!-- Reviewable:end -->
