### PR TITLE
System: Make operator|= and operator&= for enums constexpr

### DIFF
--- a/include/boo/System.hpp
+++ b/include/boo/System.hpp
@@ -37,12 +37,12 @@ static inline ComPtr<T>* ReferenceComPtr(ComPtr<T>& ptr) {
     using T = std::underlying_type_t<type>;                                                                            \
     return type(static_cast<T>(a) & static_cast<T>(b));                                                                \
   }                                                                                                                    \
-  inline type& operator|=(type& a, const type& b) {                                                                    \
+  constexpr type& operator|=(type& a, const type& b) {                                                                 \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) | static_cast<T>(b));                                                                   \
     return a;                                                                                                          \
   }                                                                                                                    \
-  inline type& operator&=(type& a, const type& b) {                                                                    \
+  constexpr type& operator&=(type& a, const type& b) {                                                                 \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) & static_cast<T>(b));                                                                   \
     return a;                                                                                                          \

--- a/include/boo/System.hpp
+++ b/include/boo/System.hpp
@@ -37,12 +37,12 @@ static inline ComPtr<T>* ReferenceComPtr(ComPtr<T>& ptr) {
     using T = std::underlying_type_t<type>;                                                                            \
     return type(static_cast<T>(a) & static_cast<T>(b));                                                                \
   }                                                                                                                    \
-  constexpr type& operator|=(type& a, const type& b) {                                                                 \
+  constexpr type& operator|=(type& a, type b) {                                                                        \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) | static_cast<T>(b));                                                                   \
     return a;                                                                                                          \
   }                                                                                                                    \
-  constexpr type& operator&=(type& a, const type& b) {                                                                 \
+  constexpr type& operator&=(type& a, type b) {                                                                        \
     using T = std::underlying_type_t<type>;                                                                            \
     a = type(static_cast<T>(a) & static_cast<T>(b));                                                                   \
     return a;                                                                                                          \


### PR DESCRIPTION
It's valid to allow these to be used within a constexpr context. Makes the enum functions more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/22)
<!-- Reviewable:end -->
