### PR TITLE
BooObject: Make ObjToken operator bool explicit

### DIFF
--- a/include/boo/BooObject.hpp
+++ b/include/boo/BooObject.hpp
@@ -69,7 +69,7 @@ public:
   T* cast() const noexcept {
     return static_cast<T*>(m_obj);
   }
-  operator bool() const noexcept { return m_obj != nullptr; }
+  explicit operator bool() const noexcept { return m_obj != nullptr; }
   void reset() noexcept {
     if (m_obj)
       m_obj->decrement();


### PR DESCRIPTION
Makes explicit conversions to bool necessary to prevent error-prone conversions to bool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/23)
<!-- Reviewable:end -->
