### PR TITLE
IGraphicsDataFactory: Default initialize semantic for VertexElementDescriptor

### DIFF
--- a/include/boo/graphicsdev/IGraphicsDataFactory.hpp
+++ b/include/boo/graphicsdev/IGraphicsDataFactory.hpp
@@ -118,7 +118,7 @@ ENABLE_BITWISE_ENUM(VertexSemantic)
 
 /** Used to create IVertexFormat */
 struct VertexElementDescriptor {
-  VertexSemantic semantic;
+  VertexSemantic semantic{};
   int semanticIdx = 0;
   VertexElementDescriptor() = default;
   VertexElementDescriptor(VertexSemantic s, int idx = 0) : semantic(s), semanticIdx(idx) {}


### PR DESCRIPTION
Makes initialization deterministic for the default constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/24)
<!-- Reviewable:end -->
