### PR TITLE
DeviceFinder: Move includes into cpp file where applicable

### DIFF
--- a/include/boo/inputdev/DeviceFinder.hpp
+++ b/include/boo/inputdev/DeviceFinder.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <unordered_set>
-#include <typeindex>
+#include <memory>
 #include <mutex>
-#include "DeviceToken.hpp"
-#include "IHIDListener.hpp"
-#include "DeviceSignature.hpp"
-#include <cstring>
-#include <cstdio>
+#include <string>
+#include <unordered_set>
+#include "boo/inputdev/DeviceSignature.hpp"
+#include "boo/inputdev/DeviceToken.hpp"
+#include "boo/inputdev/IHIDListener.hpp"
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -44,28 +43,8 @@ private:
   bool _hasToken(const std::string& path) const {
     return m_tokens.find(path) != m_tokens.end();
   }
-  bool _insertToken(std::unique_ptr<DeviceToken>&& token) {
-    if (DeviceSignature::DeviceMatchToken(*token, m_types)) {
-      m_tokensLock.lock();
-      TInsertedDeviceToken inseredTok = m_tokens.insert(std::make_pair(token->getDevicePath(), std::move(token)));
-      m_tokensLock.unlock();
-      deviceConnected(*inseredTok.first->second);
-      return true;
-    }
-    return false;
-  }
-  void _removeToken(const std::string& path) {
-    auto preCheck = m_tokens.find(path);
-    if (preCheck != m_tokens.end()) {
-      DeviceToken& tok = *preCheck->second;
-      std::shared_ptr<DeviceBase> dev = tok.m_connectedDev;
-      tok._deviceClose();
-      deviceDisconnected(tok, dev.get());
-      m_tokensLock.lock();
-      m_tokens.erase(preCheck);
-      m_tokensLock.unlock();
-    }
-  }
+  bool _insertToken(std::unique_ptr<DeviceToken>&& token);
+  void _removeToken(const std::string& path);
 
 public:
   class CDeviceTokensHandle {
@@ -83,26 +62,8 @@ public:
   };
 
   /* Application must specify its interested device-types */
-  DeviceFinder(std::unordered_set<uint64_t> types) {
-    if (skDevFinder) {
-      fmt::print(stderr, fmt("only one instance of CDeviceFinder may be constructed"));
-      abort();
-    }
-    skDevFinder = this;
-    for (const uint64_t& typeHash : types) {
-      const DeviceSignature* sigIter = BOO_DEVICE_SIGS;
-      while (sigIter->m_name) {
-        if (sigIter->m_typeHash == typeHash)
-          m_types.push_back(sigIter);
-        ++sigIter;
-      }
-    }
-  }
-  virtual ~DeviceFinder() {
-    if (m_listener)
-      m_listener->stopScanning();
-    skDevFinder = NULL;
-  }
+  DeviceFinder(std::unordered_set<uint64_t> types);
+  virtual ~DeviceFinder();
 
   /* Get interested device-type mask */
   const DeviceSignature::TDeviceSignatureSet& getTypes() const { return m_types; }
@@ -111,29 +72,11 @@ public:
   CDeviceTokensHandle getTokens() { return CDeviceTokensHandle(*this); }
 
   /* Automatic device scanning */
-  bool startScanning() {
-    if (!m_listener)
-      m_listener = IHIDListenerNew(*this);
-    if (m_listener)
-      return m_listener->startScanning();
-    return false;
-  }
-  bool stopScanning() {
-    if (!m_listener)
-      m_listener = IHIDListenerNew(*this);
-    if (m_listener)
-      return m_listener->stopScanning();
-    return false;
-  }
+  bool startScanning();
+  bool stopScanning();
 
   /* Manual device scanning */
-  bool scanNow() {
-    if (!m_listener)
-      m_listener = IHIDListenerNew(*this);
-    if (m_listener)
-      return m_listener->scanNow();
-    return false;
-  }
+  bool scanNow();
 
   virtual void deviceConnected(DeviceToken&) {}
   virtual void deviceDisconnected(DeviceToken&, DeviceBase*) {}

--- a/lib/inputdev/DeviceFinder.cpp
+++ b/lib/inputdev/DeviceFinder.cpp
@@ -41,7 +41,7 @@ bool DeviceFinder::_insertToken(std::unique_ptr<DeviceToken>&& token) {
   }
 
   m_tokensLock.lock();
-  TInsertedDeviceToken insertedTok = m_tokens.insert(std::make_pair(token->getDevicePath(), std::move(token)));
+  const TInsertedDeviceToken insertedTok = m_tokens.emplace(token->getDevicePath(), std::move(token));
   m_tokensLock.unlock();
   deviceConnected(*insertedTok.first->second);
   return true;


### PR DESCRIPTION
Avoids over-exposing inclusions that don't need to be propagated across headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/25)
<!-- Reviewable:end -->
