### PR TITLE
General: Tidy up includes

### DIFF
--- a/include/boo/DeferredWindowEvents.hpp
+++ b/include/boo/DeferredWindowEvents.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <boo/boo.hpp>
-#include <mutex>
+#include <chrono>
 #include <condition_variable>
+#include <mutex>
+#include <vector>
+
+#include "boo/IWindow.hpp"
 #include "nxstl/condition_variable"
 
 namespace boo {

--- a/include/boo/IApplication.hpp
+++ b/include/boo/IApplication.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <memory>
-#include <string>
+#include <string_view>
 #include <vector>
 
-#include "IWindow.hpp"
-#include "inputdev/DeviceFinder.hpp"
+#include "boo/IWindow.hpp"
+#include "boo/System.hpp"
+#include "boo/inputdev/DeviceFinder.hpp"
 
 namespace boo {
 class IApplication;

--- a/include/boo/IGraphicsContext.hpp
+++ b/include/boo/IGraphicsContext.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <memory>
 #include <cstdint>
+#include <memory>
 
 namespace boo {
 struct IGraphicsCommandQueue;

--- a/include/boo/IWindow.hpp
+++ b/include/boo/IWindow.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "System.hpp"
-#include <memory>
 #include <algorithm>
+#include <memory>
 #include <cstring>
+
+#include "boo/System.hpp"
 
 #undef min
 #undef max

--- a/include/boo/UWPViewProvider.hpp
+++ b/include/boo/UWPViewProvider.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "IApplication.hpp"
+#include "boo/IApplication.hpp"
 
 namespace boo {
 

--- a/include/boo/audiodev/IAudioVoiceEngine.hpp
+++ b/include/boo/audiodev/IAudioVoiceEngine.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
-#include "IAudioVoice.hpp"
-#include "IAudioSubmix.hpp"
-#include "IMIDIPort.hpp"
-#include "boo/BooObject.hpp"
+#include <cstddef>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include "boo/BooObject.hpp"
+#include "boo/audiodev/IAudioSubmix.hpp"
+#include "boo/audiodev/IAudioVoice.hpp"
+#include "boo/audiodev/IMIDIPort.hpp"
 
 namespace boo {
 struct IAudioVoiceEngine;

--- a/include/boo/audiodev/IMIDIPort.hpp
+++ b/include/boo/audiodev/IMIDIPort.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <string>
-#include <functional>
-#include <vector>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
 
 namespace boo {
 struct IAudioVoiceEngine;

--- a/include/boo/audiodev/IMIDIReader.hpp
+++ b/include/boo/audiodev/IMIDIReader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdlib>
+#include <cstddef>
 #include <cstdint>
 
 namespace boo {

--- a/include/boo/audiodev/MIDIDecoder.hpp
+++ b/include/boo/audiodev/MIDIDecoder.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "boo/audiodev/IMIDIReader.hpp"
-#include "boo/audiodev/IMIDIPort.hpp"
-#include <functional>
 #include <vector>
 
 namespace boo {
+class IMIDIReader;
 
 class MIDIDecoder {
   IMIDIReader& m_out;

--- a/include/boo/audiodev/MIDIEncoder.hpp
+++ b/include/boo/audiodev/MIDIEncoder.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "boo/audiodev/IMIDIReader.hpp"
-#include "boo/audiodev/IMIDIPort.hpp"
 
 namespace boo {
 

--- a/include/boo/boo.hpp
+++ b/include/boo/boo.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DeferredWindowEvents.hpp"
 #include "IApplication.hpp"
 #include "IWindow.hpp"
 #include "inputdev/DeviceFinder.hpp"
@@ -9,4 +10,3 @@
 #include "inputdev/NintendoPowerA.hpp"
 #include "graphicsdev/IGraphicsCommandQueue.hpp"
 #include "graphicsdev/IGraphicsDataFactory.hpp"
-#include "DeferredWindowEvents.hpp"

--- a/include/boo/graphicsdev/D3D.hpp
+++ b/include/boo/graphicsdev/D3D.hpp
@@ -2,12 +2,12 @@
 
 #if _WIN32
 
-#include "IGraphicsDataFactory.hpp"
-#include "IGraphicsCommandQueue.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include "boo/System.hpp"
+#include <cstddef>
 #include <vector>
-#include <unordered_set>
+
+#include "boo/BooObject.hpp"
+#include "boo/System.hpp"
+#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
 
 using pD3DCreateBlob = HRESULT(WINAPI*)(SIZE_T Size, ID3DBlob** ppBlob);
 extern pD3DCreateBlob D3DCreateBlobPROC;

--- a/include/boo/graphicsdev/GL.hpp
+++ b/include/boo/graphicsdev/GL.hpp
@@ -1,10 +1,11 @@
 #pragma once
 #if BOO_HAS_GL
 
-#include "IGraphicsDataFactory.hpp"
-#include "IGraphicsCommandQueue.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include "GLSLMacros.hpp"
+#include <cstdint>
+
+#include "boo/BooObject.hpp"
+#include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
+#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
 
 namespace boo {
 struct BaseGraphicsData;

--- a/include/boo/graphicsdev/IGraphicsCommandQueue.hpp
+++ b/include/boo/graphicsdev/IGraphicsCommandQueue.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "IGraphicsDataFactory.hpp"
-#include "boo/IWindow.hpp"
-#include <functional>
 #include <array>
+#include <cstddef>
+#include <functional>
+
+#include "boo/BooObject.hpp"
+#include "boo/IWindow.hpp"
+#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
 
 namespace boo {
 

--- a/include/boo/graphicsdev/IGraphicsDataFactory.hpp
+++ b/include/boo/graphicsdev/IGraphicsDataFactory.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <functional>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <initializer_list>
 #include <vector>
-#include "boo/System.hpp"
-#include "boo/ThreadLocalPtr.hpp"
+
 #include "boo/BooObject.hpp"
+#include "boo/System.hpp"
 
 #ifdef __SWITCH__
 #include <ctype.h>

--- a/include/boo/graphicsdev/Metal.hpp
+++ b/include/boo/graphicsdev/Metal.hpp
@@ -2,9 +2,11 @@
 #ifdef __APPLE__
 #if BOO_HAS_METAL
 
-#include "IGraphicsDataFactory.hpp"
-#include "IGraphicsCommandQueue.hpp"
+#include "boo/BooObject.hpp"
 #include "boo/IGraphicsContext.hpp"
+#include "boo/System.hpp"
+#include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
+#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
 
 namespace boo {
 struct BaseGraphicsData;

--- a/include/boo/graphicsdev/NX.hpp
+++ b/include/boo/graphicsdev/NX.hpp
@@ -1,9 +1,12 @@
 #pragma once
 #if BOO_HAS_NX
 
-#include "IGraphicsDataFactory.hpp"
-#include "IGraphicsCommandQueue.hpp"
-#include "nx_compiler.hpp"
+#include <unordered_map>
+
+#include "boo/BooObject.hpp"
+#include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
+#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include "boo/graphicsdev/nx_compiler.hpp"
 
 #include <switch/nvidia/fence.h>
 

--- a/include/boo/graphicsdev/Vulkan.hpp
+++ b/include/boo/graphicsdev/Vulkan.hpp
@@ -1,15 +1,15 @@
 #pragma once
 #if BOO_HAS_VULKAN
 
-#include "IGraphicsDataFactory.hpp"
-#include "IGraphicsCommandQueue.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include "GLSLMacros.hpp"
-#include <vector>
-#include <unordered_set>
-#include <unordered_map>
 #include <mutex>
 #include <queue>
+#include <unordered_map>
+#include <vector>
+
+#include "boo/BooObject.hpp"
+#include "boo/IGraphicsContext.hpp"
+#include "boo/System.hpp"
+#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
 #include "boo/graphicsdev/VulkanDispatchTable.hpp"
 
 /* Forward-declare handle type for Vulkan Memory Allocator */

--- a/include/boo/inputdev/DeviceBase.hpp
+++ b/include/boo/inputdev/DeviceBase.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <cstdint>
-#include <cstdlib>
+#include <cstddef>
 #include <cstdio>
+#include <cstdint>
 #include <memory>
-#include <vector>
 #include <mutex>
+#include <vector>
+
 #include "nxstl/mutex"
 #include "boo/System.hpp"
 

--- a/include/boo/inputdev/DeviceFinder.hpp
+++ b/include/boo/inputdev/DeviceFinder.hpp
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_set>
+
 #include "boo/inputdev/DeviceSignature.hpp"
 #include "boo/inputdev/DeviceToken.hpp"
 #include "boo/inputdev/IHIDListener.hpp"

--- a/include/boo/inputdev/DeviceSignature.hpp
+++ b/include/boo/inputdev/DeviceSignature.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
+#include <cstdint>
 #include <functional>
-#include <typeindex>
 #include <memory>
 #include <string>
+#include <typeindex>
+#include <vector>
 
 namespace boo {
 

--- a/include/boo/inputdev/DeviceToken.hpp
+++ b/include/boo/inputdev/DeviceToken.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <memory>
 #include <string>
-#include "DeviceBase.hpp"
-#include "DeviceSignature.hpp"
+
+#include "boo/inputdev/DeviceBase.hpp"
+#include "boo/inputdev/DeviceSignature.hpp"
 
 namespace boo {
 

--- a/include/boo/inputdev/DolphinSmashAdapter.hpp
+++ b/include/boo/inputdev/DolphinSmashAdapter.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <cstdint>
-#include "DeviceBase.hpp"
-#include "../System.hpp"
+
+#include "boo/System.hpp"
+#include "boo/inputdev/DeviceBase.hpp"
 
 namespace boo {
 

--- a/include/boo/inputdev/DualshockPad.hpp
+++ b/include/boo/inputdev/DualshockPad.hpp
@@ -1,8 +1,9 @@
 #pragma once
+
 #include <cstdint>
-#include <type_traits>
-#include "DeviceBase.hpp"
+
 #include "boo/System.hpp"
+#include "boo/inputdev/DeviceBase.hpp"
 
 namespace boo {
 

--- a/include/boo/inputdev/GenericPad.hpp
+++ b/include/boo/inputdev/GenericPad.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "DeviceBase.hpp"
-#include "HIDParser.hpp"
-#include <map>
-#include <mutex>
+#include <functional>
+
+#include "boo/inputdev/DeviceBase.hpp"
+#include "boo/inputdev/HIDParser.hpp"
 
 namespace boo {
 

--- a/include/boo/inputdev/HIDParser.hpp
+++ b/include/boo/inputdev/HIDParser.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "boo/System.hpp"
-#include <vector>
-#include <stack>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <stack>
+#include <utility>
+#include <vector>
+
+#include "boo/System.hpp"
 
 #if _WIN32
 #include <hidsdi.h>

--- a/include/boo/inputdev/IHIDListener.hpp
+++ b/include/boo/inputdev/IHIDListener.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <unordered_map>
+#include <memory>
 #include <mutex>
-#include "DeviceToken.hpp"
+#include <unordered_map>
+#include <utility>
+
+#include "boo/inputdev/DeviceToken.hpp"
 
 namespace boo {
 class DeviceFinder;

--- a/include/boo/inputdev/XInputPad.hpp
+++ b/include/boo/inputdev/XInputPad.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "DeviceBase.hpp"
-#include "DeviceSignature.hpp"
+#include <cstdint>
+
 #include "boo/System.hpp"
+#include "boo/inputdev/DeviceBase.hpp"
+#include "boo/inputdev/DeviceSignature.hpp"
 
 namespace boo {
 

--- a/lib/Common.hpp
+++ b/lib/Common.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "boo/BooObject.hpp"
+#include <cstddef>
 #include <iterator>
+
+#include "boo/BooObject.hpp"
 
 namespace boo {
 

--- a/lib/audiodev/AQS.cpp
+++ b/lib/audiodev/AQS.cpp
@@ -1,6 +1,7 @@
-#include "AudioVoiceEngine.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
+
 #include "boo/IApplication.hpp"
-#include "../CFPointer.hpp"
+#include "lib/CFPointer.hpp"
 
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreMIDI/CoreMIDI.h>

--- a/lib/audiodev/AudioMatrix.cpp
+++ b/lib/audiodev/AudioMatrix.cpp
@@ -1,5 +1,5 @@
-#include "AudioMatrix.hpp"
-#include "AudioVoiceEngine.hpp"
+#include "lib/audiodev/AudioMatrix.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
 #include <cstring>
 
 namespace boo {

--- a/lib/audiodev/AudioMatrix.hpp
+++ b/lib/audiodev/AudioMatrix.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "boo/audiodev/IAudioVoice.hpp"
-#include <vector>
-#include <cstdint>
-#include <limits.h>
 #include <cfloat>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+
+#include "boo/audiodev/IAudioVoice.hpp"
 
 #if __SSE__
 #include <immintrin.h>

--- a/lib/audiodev/AudioMatrixSSE.cpp
+++ b/lib/audiodev/AudioMatrixSSE.cpp
@@ -1,6 +1,5 @@
-#include "AudioMatrix.hpp"
-#include "AudioVoiceEngine.hpp"
-#include <cstring>
+#include "lib/audiodev/AudioMatrix.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
 
 #include <immintrin.h>
 

--- a/lib/audiodev/AudioSubmix.cpp
+++ b/lib/audiodev/AudioSubmix.cpp
@@ -1,7 +1,7 @@
-#include "AudioSubmix.hpp"
-#include "AudioVoiceEngine.hpp"
-#include "AudioVoice.hpp"
-#include <cstring>
+#include "lib/audiodev/AudioSubmix.hpp"
+#include "lib/audiodev/AudioVoice.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
+
 #include <algorithm>
 
 #undef min

--- a/lib/audiodev/AudioSubmix.hpp
+++ b/lib/audiodev/AudioSubmix.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "boo/audiodev/IAudioSubmix.hpp"
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <list>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
-#include "Common.hpp"
+
+#include "boo/audiodev/IAudioSubmix.hpp"
+#include "lib/audiodev/Common.hpp"
 
 #if __SSE__
 #include <immintrin.h>

--- a/lib/audiodev/AudioVoice.hpp
+++ b/lib/audiodev/AudioVoice.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <soxr.h>
 #include <mutex>
 #include <unordered_map>
+
 #include "boo/audiodev/IAudioVoice.hpp"
-#include "AudioMatrix.hpp"
-#include "AudioVoiceEngine.hpp"
-#include "Common.hpp"
+#include "lib/audiodev/AudioMatrix.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
+#include "lib/audiodev/Common.hpp"
+
+#include <soxr.h>
 
 struct AudioUnitVoiceEngine;
 struct VSTVoiceEngine;

--- a/lib/audiodev/AudioVoiceEngine.cpp
+++ b/lib/audiodev/AudioVoiceEngine.cpp
@@ -1,5 +1,7 @@
-#include "AudioVoiceEngine.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
+
 #include <cassert>
+#include <cstring>
 
 namespace boo {
 

--- a/lib/audiodev/AudioVoiceEngine.hpp
+++ b/lib/audiodev/AudioVoiceEngine.hpp
@@ -1,12 +1,18 @@
 #pragma once
 
-#include "boo/audiodev/IAudioVoiceEngine.hpp"
-#include "LtRtProcessing.hpp"
-#include "Common.hpp"
-#include "AudioVoice.hpp"
-#include "AudioSubmix.hpp"
-#include <functional>
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <memory>
 #include <mutex>
+#include <vector>
+
+#include "boo/BooObject.hpp"
+#include "boo/audiodev/IAudioVoiceEngine.hpp"
+#include "lib/audiodev/AudioSubmix.hpp"
+#include "lib/audiodev/AudioVoice.hpp"
+#include "lib/audiodev/Common.hpp"
+#include "lib/audiodev/LtRtProcessing.hpp"
 
 namespace boo {
 

--- a/lib/audiodev/Common.hpp
+++ b/lib/audiodev/Common.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <soxr.h>
-#include "../Common.hpp"
 #include "boo/audiodev/IAudioVoice.hpp"
+#include "lib/Common.hpp"
 
 namespace boo {
 

--- a/lib/audiodev/LinuxMidi.hpp
+++ b/lib/audiodev/LinuxMidi.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include "AudioVoiceEngine.hpp"
-#include "logvisor/logvisor.hpp"
+#include <csignal>
 #include <thread>
+#include <unordered_map>
+
+#include "lib/audiodev/AudioVoiceEngine.hpp"
 
 #include <alsa/asoundlib.h>
-#include <signal.h>
+#include <logvisor/logvisor.hpp>
 
 namespace boo {
 extern logvisor::Module ALSALog;

--- a/lib/audiodev/LtRtProcessing.hpp
+++ b/lib/audiodev/LtRtProcessing.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include "boo/System.hpp"
 #include "boo/audiodev/IAudioVoice.hpp"
-#include "Common.hpp"
-#include <memory>
+#include "lib/audiodev/Common.hpp"
 
 #if INTEL_IPP
 #include "ipp.h"

--- a/lib/audiodev/MIDICommon.cpp
+++ b/lib/audiodev/MIDICommon.cpp
@@ -1,4 +1,5 @@
-#include "MIDICommon.hpp"
+#include "lib/audiodev/MIDICommon.hpp"
+
 #include "boo/audiodev/IMIDIPort.hpp"
 
 namespace boo {

--- a/lib/audiodev/MIDIDecoder.cpp
+++ b/lib/audiodev/MIDIDecoder.cpp
@@ -1,7 +1,10 @@
 #include "boo/audiodev/MIDIDecoder.hpp"
-#include "MIDICommon.hpp"
-#include <memory>
+
 #include <algorithm>
+
+#include "boo/audiodev/IMIDIReader.hpp"
+#include "lib/audiodev/MIDICommon.hpp"
+
 
 namespace boo {
 

--- a/lib/audiodev/MIDIEncoder.cpp
+++ b/lib/audiodev/MIDIEncoder.cpp
@@ -1,5 +1,7 @@
 #include "boo/audiodev/MIDIEncoder.hpp"
-#include "MIDICommon.hpp"
+
+#include "boo/audiodev/IMIDIPort.hpp"
+#include "lib/audiodev/MIDICommon.hpp"
 
 namespace boo {
 

--- a/lib/audiodev/PulseAudio.cpp
+++ b/lib/audiodev/PulseAudio.cpp
@@ -1,8 +1,9 @@
-#include "AudioVoiceEngine.hpp"
-#include "logvisor/logvisor.hpp"
-#include "boo/boo.hpp"
-#include "LinuxMidi.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
 
+#include "boo/boo.hpp"
+#include "lib/audiodev/LinuxMidi.hpp"
+
+#include <logvisor/logvisor.hpp>
 #include <pulse/pulseaudio.h>
 #include <unistd.h>
 

--- a/lib/audiodev/WASAPI.cpp
+++ b/lib/audiodev/WASAPI.cpp
@@ -1,14 +1,16 @@
-#include "../win/Win32Common.hpp"
-#include "AudioVoiceEngine.hpp"
-#include "logvisor/logvisor.hpp"
+#include "lib/win/Win32Common.hpp"
+
+#include <iterator>
+
 #include "boo/IApplication.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
 
 #include <Mmdeviceapi.h>
 #include <Audioclient.h>
 #include <mmsystem.h>
 #include <Functiondiscoverykeys_devpkey.h>
 
-#include <iterator>
+#include <logvisor/logvisor.hpp>
 
 #ifdef TE_VIRTUAL_MIDI
 #include <teVirtualMIDI.h>

--- a/lib/audiodev/WAVOut.cpp
+++ b/lib/audiodev/WAVOut.cpp
@@ -1,6 +1,9 @@
-#include "AudioVoiceEngine.hpp"
-#include "logvisor/logvisor.hpp"
+#include "lib/audiodev/AudioVoiceEngine.hpp"
+
+#include <cstdio>
+
 #include "boo/audiodev/IAudioVoiceEngine.hpp"
+#include <logvisor/logvisor.hpp>
 
 namespace boo {
 

--- a/lib/graphicsdev/Common.hpp
+++ b/lib/graphicsdev/Common.hpp
@@ -14,7 +14,7 @@
 
 #include "boo/graphicsdev/IGraphicsDataFactory.hpp"
 #include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
-#include "../Common.hpp"
+#include "lib/Common.hpp"
 
 namespace boo {
 

--- a/lib/graphicsdev/D3D11.cpp
+++ b/lib/graphicsdev/D3D11.cpp
@@ -1,12 +1,12 @@
 #include "../win/Win32Common.hpp"
 #include "boo/graphicsdev/D3D.hpp"
+#include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
 #include "boo/IGraphicsContext.hpp"
-#include "Common.hpp"
+#include "lib/graphicsdev/Common.hpp"
 
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
-#include <forward_list>
 #include <mutex>
 #include <thread>
 #include <vector>

--- a/lib/graphicsdev/GL.cpp
+++ b/lib/graphicsdev/GL.cpp
@@ -1,7 +1,10 @@
 #include "boo/graphicsdev/GL.hpp"
 #include "boo/graphicsdev/glew.h"
+#include "boo/graphicsdev/GLSLMacros.hpp"
+
 #include "boo/IApplication.hpp"
-#include "Common.hpp"
+#include "boo/IGraphicsContext.hpp"
+#include "lib/graphicsdev/Common.hpp"
 
 #include <array>
 #include <condition_variable>
@@ -15,7 +18,7 @@
 #include <logvisor/logvisor.hpp>
 
 #if _WIN32
-#include "../win/WinCommon.hpp"
+#include "lib/win/WinCommon.hpp"
 #endif
 
 #undef min

--- a/lib/graphicsdev/GLX.cpp
+++ b/lib/graphicsdev/GLX.cpp
@@ -1,5 +1,5 @@
 #include "boo/graphicsdev/glxew.h"
-#include "logvisor/logvisor.hpp"
+#include <logvisor/logvisor.hpp>
 
 namespace boo {
 static logvisor::Module Log("boo::GLX");

--- a/lib/graphicsdev/Metal.mm
+++ b/lib/graphicsdev/Metal.mm
@@ -1,16 +1,17 @@
-#include "../mac/CocoaCommon.hpp"
+#include "lib/mac/CocoaCommon.hpp"
 
 #if BOO_HAS_METAL
 
-#include "logvisor/logvisor.hpp"
 #include "boo/IApplication.hpp"
-#include "boo/graphicsdev/Metal.hpp"
 #include "boo/IGraphicsContext.hpp"
-#include "Common.hpp"
-#include <vector>
+#include "boo/graphicsdev/Metal.hpp"
+#include "lib/graphicsdev/Common.hpp"
+
 #include <unordered_map>
 #include <unordered_set>
-#include "xxhash/xxhash.h"
+#include <vector>
+
+#include <logvisor/logvisor.hpp>
 
 #if !__has_feature(objc_arc)
 #error ARC Required

--- a/lib/graphicsdev/Vulkan.cpp
+++ b/lib/graphicsdev/Vulkan.cpp
@@ -1,15 +1,18 @@
 #include "boo/graphicsdev/Vulkan.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include <vector>
+
 #include <array>
 #include <cmath>
+#include <vector>
+
 #include <glslang/Public/ShaderLang.h>
 #include <StandAlone/ResourceLimits.h>
 #include <SPIRV/GlslangToSpv.h>
 #include <SPIRV/disassemble.h>
+
+#include "boo/IGraphicsContext.hpp"
 #include "boo/graphicsdev/GLSLMacros.hpp"
-#include "Common.hpp"
-#include "xxhash/xxhash.h"
+#include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
+#include "lib/graphicsdev/Common.hpp"
 
 #define AMD_PAL_HACK 1
 
@@ -17,7 +20,7 @@
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
 #include "vk_mem_alloc.h"
 
-#include "logvisor/logvisor.hpp"
+#include <logvisor/logvisor.hpp>
 
 #define BOO_VK_MAX_DESCRIPTOR_SETS 65536
 

--- a/lib/graphicsdev/nx/NX.cpp
+++ b/lib/graphicsdev/nx/NX.cpp
@@ -1,9 +1,13 @@
-#include "logvisor/logvisor.hpp"
 #include "boo/graphicsdev/NX.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+
 #include "boo/IGraphicsContext.hpp"
 #include "boo/graphicsdev/GLSLMacros.hpp"
-#include "../Common.hpp"
-#include "xxhash/xxhash.h"
+#include "lib/graphicsdev/Common.hpp"
 
 #include "main/shaderobj.h"
 #include "st_program.h"
@@ -18,6 +22,9 @@ extern "C" {
 #include "nvc0/nvc0_program.h"
 #include "gallium/winsys/nouveau/switch/nouveau_switch_public.h"
 }
+
+#include <logvisor/logvisor.hpp>
+#include <xxhash/xxhash.h>
 
 #include <switch.h>
 

--- a/lib/inputdev/DeviceBase.cpp
+++ b/lib/inputdev/DeviceBase.cpp
@@ -1,7 +1,6 @@
 #include "boo/inputdev/DeviceBase.hpp"
 #include "boo/inputdev/DeviceToken.hpp"
-#include "IHIDDevice.hpp"
-#include <cstdarg>
+#include "lib/inputdev/IHIDDevice.hpp"
 
 namespace boo {
 

--- a/lib/inputdev/DeviceSignature.cpp
+++ b/lib/inputdev/DeviceSignature.cpp
@@ -1,7 +1,7 @@
 #include "boo/inputdev/DeviceSignature.hpp"
 #include "boo/inputdev/DeviceToken.hpp"
 #include "boo/inputdev/GenericPad.hpp"
-#include "IHIDDevice.hpp"
+#include "lib/inputdev/IHIDDevice.hpp"
 
 namespace boo {
 

--- a/lib/inputdev/DolphinSmashAdapter.cpp
+++ b/lib/inputdev/DolphinSmashAdapter.cpp
@@ -1,5 +1,6 @@
 #include "boo/inputdev/DolphinSmashAdapter.hpp"
 #include "boo/inputdev/DeviceSignature.hpp"
+
 #include <cstdio>
 #include <cstring>
 

--- a/lib/inputdev/DualshockPad.cpp
+++ b/lib/inputdev/DualshockPad.cpp
@@ -1,10 +1,11 @@
 #include "boo/inputdev/DualshockPad.hpp"
 #include "boo/inputdev/DeviceSignature.hpp"
+
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <iostream>
 #include <cstdio>
-#include <memory.h>
+#include <cstring>
+#include <iostream>
 
 #ifdef _MSC_VER
 inline uint16_t bswap16(uint16_t val) { return _byteswap_ushort(val); }

--- a/lib/inputdev/HIDDeviceIOKit.cpp
+++ b/lib/inputdev/HIDDeviceIOKit.cpp
@@ -1,9 +1,12 @@
-#include "IHIDDevice.hpp"
+#include "lib/inputdev/IHIDDevice.hpp"
+
+#include <thread>
+
+#include "lib/inputdev/IOKitPointer.hpp"
+
 #include <IOKit/hid/IOHIDLib.h>
 #include <IOKit/hid/IOHIDDevicePlugin.h>
 #include <IOKit/usb/IOUSBLib.h>
-#include "IOKitPointer.hpp"
-#include <thread>
 
 namespace boo {
 

--- a/lib/inputdev/HIDDeviceNX.cpp
+++ b/lib/inputdev/HIDDeviceNX.cpp
@@ -1,4 +1,4 @@
-#include "IHIDDevice.hpp"
+#include "lib/inputdev/IHIDDevice.hpp"
 
 namespace boo {
 

--- a/lib/inputdev/HIDDeviceUWP.cpp
+++ b/lib/inputdev/HIDDeviceUWP.cpp
@@ -1,5 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS 1 /* STFU MSVC */
-#include "IHIDDevice.hpp"
+
+#include "lib/inputdev/IHIDDevice.hpp"
+
 #include "boo/inputdev/DeviceToken.hpp"
 #include "boo/inputdev/DeviceBase.hpp"
 

--- a/lib/inputdev/HIDDeviceUdev.cpp
+++ b/lib/inputdev/HIDDeviceUdev.cpp
@@ -1,22 +1,24 @@
-#include "IHIDDevice.hpp"
+#include "lib/inputdev/IHIDDevice.hpp"
+
+#include <condition_variable>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <thread>
+
 #include "boo/inputdev/DeviceToken.hpp"
 #include "boo/inputdev/DeviceBase.hpp"
-#include <thread>
-#include <mutex>
-#include <condition_variable>
+#include "boo/inputdev/HIDParser.hpp"
 
-#include <cstdio>
+#include <fcntl.h>
 #include <libudev.h>
-#include <stropts.h>
 #include <linux/usb/ch9.h>
 #include <linux/usbdevice_fs.h>
 #include <linux/input.h>
 #include <linux/hidraw.h>
-#include <fcntl.h>
+#include <stropts.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-#include <cstring>
-#include "boo/inputdev/HIDParser.hpp"
 
 namespace boo {
 

--- a/lib/inputdev/HIDDeviceWinUSB.cpp
+++ b/lib/inputdev/HIDDeviceWinUSB.cpp
@@ -1,5 +1,6 @@
 #define _CRT_SECURE_NO_WARNINGS 1 /* STFU MSVC */
-#include "IHIDDevice.hpp"
+#include "lib/inputdev/IHIDDevice.hpp"
+
 #include "boo/inputdev/DeviceToken.hpp"
 #include "boo/inputdev/DeviceBase.hpp"
 

--- a/lib/inputdev/HIDListenerUWP.cpp
+++ b/lib/inputdev/HIDListenerUWP.cpp
@@ -1,4 +1,5 @@
 #define _CRT_SECURE_NO_WARNINGS 1 /* STFU MSVC */
+
 #include "boo/inputdev/IHIDListener.hpp"
 #include "boo/inputdev/DeviceFinder.hpp"
 

--- a/lib/inputdev/HIDListenerWinUSB.cpp
+++ b/lib/inputdev/HIDListenerWinUSB.cpp
@@ -1,9 +1,12 @@
 #define _CRT_SECURE_NO_WARNINGS 1 /* STFU MSVC */
+
 #include "boo/inputdev/IHIDListener.hpp"
-#include "boo/inputdev/DeviceFinder.hpp"
-#include "boo/inputdev/XInputPad.hpp"
+
 #include <cstring>
 #include <thread>
+
+#include "boo/inputdev/DeviceFinder.hpp"
+#include "boo/inputdev/XInputPad.hpp"
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1

--- a/lib/inputdev/HIDParser.cpp
+++ b/lib/inputdev/HIDParser.cpp
@@ -1,6 +1,8 @@
 #include "boo/inputdev/HIDParser.hpp"
-#include <map>
+
 #include <algorithm>
+#include <map>
+#include <type_traits>
 
 #undef min
 #undef max

--- a/lib/inputdev/IHIDDevice.hpp
+++ b/lib/inputdev/IHIDDevice.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "boo/inputdev/DeviceToken.hpp"
-#include "boo/inputdev/DeviceBase.hpp"
 #include <memory>
+
+#include "boo/inputdev/DeviceBase.hpp"
+#include "boo/inputdev/DeviceToken.hpp"
 
 #if _WIN32
 #include <hidsdi.h>

--- a/lib/inputdev/IOKitPointer.hpp
+++ b/lib/inputdev/IOKitPointer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../CFPointer.hpp"
+#include "lib/CFPointer.hpp"
 #include <IOKit/IOTypes.h>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/IOCFPlugIn.h>

--- a/lib/inputdev/NintendoPowerA.cpp
+++ b/lib/inputdev/NintendoPowerA.cpp
@@ -1,6 +1,9 @@
 #include "boo/inputdev/NintendoPowerA.hpp"
+
+#include <cstring>
+
 #include "boo/inputdev/DeviceSignature.hpp"
-#include <memory.h>
+
 namespace boo {
 NintendoPowerA::NintendoPowerA(DeviceToken* token)
 : TDeviceBase<INintendoPowerACallback>(dev_typeid(NintendoPowerA), token) {}

--- a/lib/mac/ApplicationCocoa.mm
+++ b/lib/mac/ApplicationCocoa.mm
@@ -1,12 +1,13 @@
 #include <AppKit/AppKit.h>
+
 #include <thread>
 
 #include "boo/IApplication.hpp"
 #include "boo/graphicsdev/Metal.hpp"
-#include "CocoaCommon.hpp"
-#include "../Common.hpp"
+#include "lib/Common.hpp"
+#include "lib/mac/CocoaCommon.hpp"
 
-#include "logvisor/logvisor.hpp"
+#include <logvisor/logvisor.hpp>
 
 #if !__has_feature(objc_arc)
 #error ARC Required

--- a/lib/mac/CocoaCommon.hpp
+++ b/lib/mac/CocoaCommon.hpp
@@ -9,8 +9,9 @@
 
 #include <Metal/Metal.h>
 #include <QuartzCore/CAMetalLayer.h>
-#include <unordered_map>
+
 #include <mutex>
+#include <unordered_map>
 
 namespace boo {
 class IWindow;

--- a/lib/mac/WindowCocoa.mm
+++ b/lib/mac/WindowCocoa.mm
@@ -1,10 +1,10 @@
 #include "boo/graphicsdev/Metal.hpp"
-#include "CocoaCommon.hpp"
 
 #include "boo/IApplication.hpp"
 #include "boo/IGraphicsContext.hpp"
 #include "boo/IWindow.hpp"
 #include "boo/audiodev/IAudioVoiceEngine.hpp"
+#include "lib/mac/CocoaCommon.hpp"
 
 #include <condition_variable>
 #include <memory>

--- a/lib/nx/WindowNX.cpp
+++ b/lib/nx/WindowNX.cpp
@@ -1,8 +1,9 @@
 #include "boo/IWindow.hpp"
+
 #include "boo/IGraphicsContext.hpp"
-#include "logvisor/logvisor.hpp"
 #include "boo/graphicsdev/NX.hpp"
 
+#include <logvisor/logvisor.hpp>
 #include <switch.h>
 
 namespace boo {

--- a/lib/win/ApplicationUWP.cpp
+++ b/lib/win/ApplicationUWP.cpp
@@ -1,4 +1,4 @@
-#include "UWPCommon.hpp"
+#include "lib/win/UWPCommon.hpp"
 
 using namespace Windows::Foundation;
 using namespace Windows::UI::Core;
@@ -12,12 +12,15 @@ using namespace Platform;
 #define D3D11_CREATE_DEVICE_FLAGS 0
 #endif
 
-#include "boo/System.hpp"
+#include <cstdlib>
+
 #include "boo/IApplication.hpp"
-#include "boo/inputdev/DeviceFinder.hpp"
-#include "boo/graphicsdev/D3D.hpp"
-#include "logvisor/logvisor.hpp"
+#include "boo/System.hpp"
 #include "boo/UWPViewProvider.hpp"
+#include "boo/graphicsdev/D3D.hpp"
+#include "boo/inputdev/DeviceFinder.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 #if _WIN32_WINNT_WIN10
 PFN_D3D12_SERIALIZE_ROOT_SIGNATURE D3D12SerializeRootSignaturePROC = nullptr;

--- a/lib/win/ApplicationWin32.cpp
+++ b/lib/win/ApplicationWin32.cpp
@@ -1,4 +1,5 @@
-#include "Win32Common.hpp"
+#include "lib/win/Win32Common.hpp"
+
 #include <shellapi.h>
 #include <initguid.h>
 #include <Usbiodef.h>
@@ -15,18 +16,20 @@ PFN_GetScaleFactorForMonitor MyGetScaleFactorForMonitor = nullptr;
 #define D3D11_CREATE_DEVICE_FLAGS 0
 #endif
 
-#include "boo/System.hpp"
+#include <condition_variable>
+#include <cstdlib>
+#include <mutex>
+
 #include "boo/IApplication.hpp"
-#include "boo/inputdev/DeviceFinder.hpp"
+#include "boo/System.hpp"
 #include "boo/graphicsdev/D3D.hpp"
-#include "logvisor/logvisor.hpp"
+#include "boo/inputdev/DeviceFinder.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 #if BOO_HAS_VULKAN
 #include "boo/graphicsdev/Vulkan.hpp"
 #endif
-
-#include <condition_variable>
-#include <mutex>
 
 DWORD g_mainThreadId = 0;
 std::mutex g_nwmt;

--- a/lib/win/UWPCommon.hpp
+++ b/lib/win/UWPCommon.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "WinCommon.hpp"
+#include "lib/win/WinCommon.hpp"
 
 struct Boo3DAppContextUWP : Boo3DAppContext {
   bool isFullscreen(const boo::IWindow* window) {

--- a/lib/win/WinCommon.hpp
+++ b/lib/win/WinCommon.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <string>
 #include <unordered_map>
+
 #include "boo/IWindow.hpp"
 
 namespace boo {

--- a/lib/win/WindowUWP.cpp
+++ b/lib/win/WindowUWP.cpp
@@ -1,11 +1,12 @@
-#include "UWPCommon.hpp"
-#include "boo/IApplication.hpp"
-#include "boo/IWindow.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include "logvisor/logvisor.hpp"
+#include "lib/win/UWPCommon.hpp"
 
-#include "boo/graphicsdev/D3D.hpp"
+#include "boo/IApplication.hpp"
+#include "boo/IGraphicsContext.hpp"
+#include "boo/IWindow.hpp"
 #include "boo/audiodev/IAudioVoiceEngine.hpp"
+#include "boo/graphicsdev/D3D.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 using namespace Windows::UI;
 using namespace Windows::UI::Core;

--- a/lib/win/WindowWin32.cpp
+++ b/lib/win/WindowWin32.cpp
@@ -1,15 +1,16 @@
-#include "Win32Common.hpp"
-#include <Windowsx.h>
-#include "boo/IApplication.hpp"
-#include "boo/IWindow.hpp"
-#include "boo/IGraphicsContext.hpp"
-#include "logvisor/logvisor.hpp"
+#include "lib/win/Win32Common.hpp"
 
+#include <Windowsx.h>
+
+#include "boo/IApplication.hpp"
+#include "boo/IGraphicsContext.hpp"
+#include "boo/IWindow.hpp"
+
+#include "boo/audiodev/IAudioVoiceEngine.hpp"
 #include "boo/graphicsdev/D3D.hpp"
 #include "boo/graphicsdev/GL.hpp"
 #include "boo/graphicsdev/glew.h"
 #include "boo/graphicsdev/wglew.h"
-#include "boo/audiodev/IAudioVoiceEngine.hpp"
 
 #if BOO_HAS_VULKAN
 #include "boo/graphicsdev/Vulkan.hpp"
@@ -18,6 +19,8 @@
 #if _WIN32_WINNT_WIN10
 #include <dxgi1_5.h>
 #endif
+
+#include <logvisor/logvisor.hpp>
 
 static const int ContextAttribs[] = {WGL_CONTEXT_MAJOR_VERSION_ARB, 3, WGL_CONTEXT_MINOR_VERSION_ARB, 3,
                                      WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,

--- a/lib/x11/ApplicationUnix.cpp
+++ b/lib/x11/ApplicationUnix.cpp
@@ -4,11 +4,14 @@
 
 #define APPLICATION_UNIX_CPP
 
-#include <dbus/dbus.h>
 #include <cstdint>
-#include <unistd.h>
-#include "logvisor/logvisor.hpp"
+#include <cstdlib>
+
 #include "boo/IApplication.hpp"
+
+#include <dbus/dbus.h>
+#include <logvisor/logvisor.hpp>
+#include <unistd.h>
 
 namespace boo {
 static logvisor::Module Log("boo::ApplicationUnix");

--- a/lib/x11/ApplicationXlib.hpp
+++ b/lib/x11/ApplicationXlib.hpp
@@ -4,7 +4,7 @@
 
 #include "boo/IApplication.hpp"
 #include "boo/graphicsdev/GL.hpp"
-#include "../Common.hpp"
+#include "lib/Common.hpp"
 
 #include <X11/Xlib.h>
 #include <X11/XKBlib.h>
@@ -16,6 +16,7 @@
 #include <dbus/dbus.h>
 DBusConnection* RegisterDBus(const char* appName, bool& isFirst);
 
+#include <clocale>
 #include <condition_variable>
 #include <csignal>
 #include <locale>

--- a/lib/x11/WindowWayland.cpp
+++ b/lib/x11/WindowWayland.cpp
@@ -1,4 +1,5 @@
 #include "boo/IWindow.hpp"
+
 #include "boo/IGraphicsContext.hpp"
 #include "boo/audiodev/IAudioVoiceEngine.hpp"
 

--- a/lib/x11/WindowXlib.cpp
+++ b/lib/x11/WindowXlib.cpp
@@ -1,10 +1,11 @@
 #include "boo/IWindow.hpp"
-#include "boo/IGraphicsContext.hpp"
+
 #include "boo/IApplication.hpp"
-#include "boo/graphicsdev/GL.hpp"
+#include "boo/IGraphicsContext.hpp"
 #include "boo/audiodev/IAudioVoiceEngine.hpp"
+#include "boo/graphicsdev/GL.hpp"
 #include "boo/graphicsdev/glew.h"
-#include "../Common.hpp"
+#include "lib/Common.hpp"
 
 #if BOO_HAS_VULKAN
 #include "boo/graphicsdev/Vulkan.hpp"
@@ -35,7 +36,7 @@
 #include <X11/extensions/Xrandr.h>
 #include <logvisor/logvisor.hpp>
 
-#include "XlibCommon.hpp"
+#include "lib/x11/XlibCommon.hpp"
 
 #define REF_DPMM 3.78138
 #define FS_ATOM "_NET_WM_STATE_FULLSCREEN"

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,14 +1,15 @@
-#include <cstdio>
-#include <cmath>
 #include <boo/boo.hpp>
-#include <boo/graphicsdev/GL.hpp>
-#include <boo/graphicsdev/Vulkan.hpp>
 #include <boo/graphicsdev/D3D.hpp>
+#include <boo/graphicsdev/GL.hpp>
+#include <boo/graphicsdev/GLSLMacros.hpp>
 #include <boo/graphicsdev/Metal.hpp>
-#include <thread>
-#include <mutex>
+#include <boo/graphicsdev/Vulkan.hpp>
+
 #include <condition_variable>
-#include "logvisor/logvisor.hpp"
+#include <cstdio>
+#include <thread>
+
+#include <logvisor/logvisor.hpp>
 
 namespace boo {
 


### PR DESCRIPTION
Alphabetizes includes and resolves quite a few instances of indirect inclusions, making the requirements of several interfaces explicit. This also trims out includes that aren't actually necessary (likely due to changes in the API over time).

This should make the inclusion lists nicer to read and avoid some inclusions in headers where they're not necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/26)
<!-- Reviewable:end -->
