### PR TITLE
General: Correct fmt specifiers

### DIFF
--- a/lib/audiodev/AQS.cpp
+++ b/lib/audiodev/AQS.cpp
@@ -73,7 +73,7 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
     argSize = sizeof(devId);
     if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, sizeof(devName), &devName, &argSize,
                                    &devId) != noErr) {
-      Log.report(logvisor::Error, fmt("unable to resolve audio device UID %s, using default"),
+      Log.report(logvisor::Error, fmt("unable to resolve audio device UID {}, using default"),
                  CFStringGetCStringPtr(devName, kCFStringEncodingUTF8));
       argSize = sizeof(devId);
       propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
@@ -758,7 +758,7 @@ struct AQSAudioVoiceEngine : BaseAudioVoiceEngine {
           chMapOut.m_channels[4] = AudioChannel::FrontCenter;
           break;
         default:
-          Log.report(logvisor::Warning, fmt("unknown channel layout %u; using stereo"), layout.mChannelLayoutTag);
+          Log.report(logvisor::Warning, fmt("unknown channel layout {}; using stereo"), layout.mChannelLayoutTag);
           chMapOut.m_channelCount = 2;
           chMapOut.m_channels[0] = AudioChannel::FrontLeft;
           chMapOut.m_channels[1] = AudioChannel::FrontRight;

--- a/lib/audiodev/LtRtProcessing.cpp
+++ b/lib/audiodev/LtRtProcessing.cpp
@@ -259,12 +259,12 @@ LtRtProcessing::LtRtProcessing(int _5msFrames, const AudioVoiceEngineMixInfo& mi
 template <typename T>
 void LtRtProcessing::Process(const T* input, T* output, int frameCount) {
 #if 0
-    for (int i=0 ; i<frameCount ; ++i)
-    {
-        output[i * 2] = input[i * 5 + 3];
-        output[i * 2 + 1] = input[i * 5 + 4];
-    }
-    return;
+  for (int i=0 ; i<frameCount ; ++i)
+  {
+    output[i * 2] = input[i * 5 + 3];
+    output[i * 2 + 1] = input[i * 5 + 4];
+  }
+  return;
 #endif
 
   int outFramesRem = frameCount;
@@ -273,14 +273,14 @@ void LtRtProcessing::Process(const T* input, T* output, int frameCount) {
   int tail = std::min(m_windowFrames * 2, m_bufferTail + frameCount);
   int samples = (tail - m_bufferTail) * 5;
   memmove(&inBuf[m_bufferTail * 5], input, samples * sizeof(T));
-  // printf("input %d to %d\n", tail - m_bufferTail, m_bufferTail);
+  // fmt::print("input {} to {}\n", tail - m_bufferTail, m_bufferTail);
   input += samples;
   frameCount -= tail - m_bufferTail;
 
   int head = std::min(m_windowFrames * 2, m_bufferHead + outFramesRem);
   samples = (head - m_bufferHead) * 2;
   memmove(output, outBuf + m_bufferHead * 2, samples * sizeof(T));
-  // printf("output %d from %d\n", head - m_bufferHead, m_bufferHead);
+  // fmt::print("output {} from {}\n", head - m_bufferHead, m_bufferHead);
   output += samples;
   outFramesRem -= head - m_bufferHead;
 
@@ -300,7 +300,7 @@ void LtRtProcessing::Process(const T* input, T* output, int frameCount) {
       for (int i = 0; i < m_windowFrames; ++i, ++delayI) {
         out[i * 2] = ClampFull<T>(in[delayI * 5] + 0.7071068f * in[delayI * 5 + 2]);
         out[i * 2 + 1] = ClampFull<T>(in[delayI * 5 + 1] + 0.7071068f * in[delayI * 5 + 2]);
-        // printf("in %d out %d\n", bufIdx * m_5msFrames + delayI, bufIdx * m_5msFrames + i);
+        // fmt::print("in {} out {}\n", bufIdx * m_5msFrames + delayI, bufIdx * m_5msFrames + i);
       }
     } else {
       int delayI = m_windowFrames * 2 - m_halfFrames;
@@ -308,13 +308,13 @@ void LtRtProcessing::Process(const T* input, T* output, int frameCount) {
       for (i = 0; i < m_halfFrames; ++i, ++delayI) {
         out[i * 2] = ClampFull<T>(in[delayI * 5] + 0.7071068f * in[delayI * 5 + 2]);
         out[i * 2 + 1] = ClampFull<T>(in[delayI * 5 + 1] + 0.7071068f * in[delayI * 5 + 2]);
-        // printf("in %d out %d\n", bufIdx * m_5msFrames + delayI, bufIdx * m_5msFrames + i);
+        // fmt::print("in {} out {}\n", bufIdx * m_5msFrames + delayI, bufIdx * m_5msFrames + i);
       }
       delayI = 0;
       for (; i < m_windowFrames; ++i, ++delayI) {
         out[i * 2] = ClampFull<T>(in[delayI * 5] + 0.7071068f * in[delayI * 5 + 2]);
         out[i * 2 + 1] = ClampFull<T>(in[delayI * 5 + 1] + 0.7071068f * in[delayI * 5 + 2]);
-        // printf("in %d out %d\n", bufIdx * m_5msFrames + delayI, bufIdx * m_5msFrames + i);
+        // fmt::print("in {} out {}\n", bufIdx * m_5msFrames + delayI, bufIdx * m_5msFrames + i);
       }
     }
 #if INTEL_IPP
@@ -328,14 +328,14 @@ void LtRtProcessing::Process(const T* input, T* output, int frameCount) {
   if (frameCount) {
     samples = frameCount * 5;
     memmove(inBuf, input, samples * sizeof(T));
-    // printf("input %d to %d\n", frameCount, 0);
+    // fmt::print("input {} to {}\n", frameCount, 0);
     m_bufferTail = frameCount;
   }
 
   if (outFramesRem) {
     samples = outFramesRem * 2;
     memmove(output, outBuf, samples * sizeof(T));
-    // printf("output %d from %d\n", outFramesRem, 0);
+    // fmt::print("output {} from {}\n", outFramesRem, 0);
     m_bufferHead = outFramesRem;
   }
 }

--- a/lib/audiodev/WASAPI.cpp
+++ b/lib/audiodev/WASAPI.cpp
@@ -121,7 +121,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
 #if !WINDOWS_STORE
     if (!m_device) {
       if (FAILED(m_enumerator->GetDevice(MBSTWCS(m_sinkName.c_str()).c_str(), &m_device))) {
-        Log.report(logvisor::Error, fmt("unable to obtain audio device %s"), m_sinkName);
+        Log.report(logvisor::Error, fmt("unable to obtain audio device {}"), m_sinkName);
         m_device.Reset();
         return;
       }
@@ -204,7 +204,7 @@ struct WASAPIAudioVoiceEngine : BaseAudioVoiceEngine {
       chMapOut.m_channels[7] = AudioChannel::SideRight;
       break;
     default:
-      Log.report(logvisor::Warning, fmt("unknown channel layout %u; using stereo"), pwfx->Format.nChannels);
+      Log.report(logvisor::Warning, fmt("unknown channel layout {}; using stereo"), pwfx->Format.nChannels);
       chMapOut.m_channelCount = 2;
       chMapOut.m_channels[0] = AudioChannel::FrontLeft;
       chMapOut.m_channels[1] = AudioChannel::FrontRight;

--- a/lib/graphicsdev/D3D11.cpp
+++ b/lib/graphicsdev/D3D11.cpp
@@ -750,9 +750,10 @@ struct D3D11ShaderDataBinding : public GraphicsDataNode<IShaderDataBinding> {
       m_ubufNumConsts.reset(new UINT[ubufCount]);
       for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-        if (ubufOffs[i] % 256)
-          Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset %d provided to newShaderDataBinding"),
-                     int(i));
+        if (ubufOffs[i] % 256) {
+          Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset {} provided to newShaderDataBinding"),
+                     i);
+        }
 #endif
         m_ubufFirstConsts[i] = ubufOffs[i] / 16;
         m_ubufNumConsts[i] = ((ubufSizes[i] + 255) & ~255) / 16;
@@ -760,8 +761,9 @@ struct D3D11ShaderDataBinding : public GraphicsDataNode<IShaderDataBinding> {
     }
     for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-      if (!ubufs[i])
-        Log.report(logvisor::Fatal, fmt("null uniform-buffer %d provided to newShaderDataBinding"), int(i));
+      if (!ubufs[i]) {
+        Log.report(logvisor::Fatal, fmt("null uniform-buffer {} provided to newShaderDataBinding"), i);
+      }
 #endif
       m_ubufs.push_back(ubufs[i]);
     }
@@ -1579,7 +1581,7 @@ std::vector<uint8_t> D3D11DataFactory::CompileHLSL(const char* source, PipelineS
   if (FAILED(D3DCompilePROC(source, strlen(source), "Boo HLSL Source", nullptr, nullptr, "main",
                             D3DShaderTypes[int(stage)], BOO_D3DCOMPILE_FLAG, 0, &blobOut, &errBlob))) {
     fmt::print(fmt("{}\n"), source);
-    Log.report(logvisor::Fatal, fmt("error compiling shader: %s"), errBlob->GetBufferPointer());
+    Log.report(logvisor::Fatal, fmt("error compiling shader: {}"), errBlob->GetBufferPointer());
     return {};
   }
   std::vector<uint8_t> ret(blobOut->GetBufferSize());

--- a/lib/graphicsdev/GL.cpp
+++ b/lib/graphicsdev/GL.cpp
@@ -901,15 +901,18 @@ public:
         if (const GLShaderStage* stage = shader.cast<GLShaderStage>()) {
           for (const auto& name : stage->getBlockNames()) {
             GLint uniLoc = glGetUniformBlockIndex(m_prog, name.first.c_str());
-            // if (uniLoc < 0)
-            //    Log.report(logvisor::Warning, fmt("unable to find uniform block '%s'"), uniformBlockNames[i]);
+            // if (uniLoc < 0) {
+            //    Log.report(logvisor::Warning, fmt("unable to find uniform block '{}'"), uniformBlockNames[i]);
+            // }
             m_uniLocs[name.second] = uniLoc;
           }
           for (const auto& name : stage->getTexNames()) {
             GLint texLoc = glGetUniformLocation(m_prog, name.first.c_str());
-            if (texLoc < 0) { /* Log.report(logvisor::Warning, fmt("unable to find sampler variable '%s'"), texNames[i]); */
-            } else
+            if (texLoc < 0) {
+              // Log.report(logvisor::Warning, fmt("unable to find sampler variable '{}'"), texNames[i]);
+            } else {
               glUniform1i(texLoc, name.second);
+            }
           }
         }
       }
@@ -1957,8 +1960,9 @@ GLShaderDataBinding(const ObjToken<BaseGraphicsData>& d, const ObjToken<IShaderP
     m_ubufOffs.reserve(ubufCount);
     for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-      if (ubufOffs[i] % 256)
-        Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset {} provided to newShaderDataBinding"), int(i));
+      if (ubufOffs[i] % 256) {
+        Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset {} provided to newShaderDataBinding"), i);
+      }
 #endif
       m_ubufOffs.emplace_back(ubufOffs[i], (ubufSizes[i] + 255) & ~255);
     }
@@ -1966,8 +1970,9 @@ GLShaderDataBinding(const ObjToken<BaseGraphicsData>& d, const ObjToken<IShaderP
   m_ubufs.reserve(ubufCount);
   for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-    if (!ubufs[i])
-      Log.report(logvisor::Fatal, fmt("null uniform-buffer {} provided to newShaderDataBinding"), int(i));
+    if (!ubufs[i]) {
+      Log.report(logvisor::Fatal, fmt("null uniform-buffer {} provided to newShaderDataBinding"), i);
+    }
 #endif
     m_ubufs.push_back(ubufs[i]);
   }

--- a/lib/graphicsdev/Metal.mm
+++ b/lib/graphicsdev/Metal.mm
@@ -903,11 +903,13 @@ class MetalShaderStage : public GraphicsDataNode<IShaderStage> {
       shaderLib = [ctx->m_dev newLibraryWithSource:@((const char*) (data + 1))
                                            options:compOpts
                                              error:&err];
-      if (!shaderLib)
+      if (!shaderLib) {
         fmt::print(fmt("{}\n"), data + 1);
+      }
     }
-    if (!shaderLib)
-      Log.report(logvisor::Fatal, fmt("error creating library: %s"), [[err localizedDescription] UTF8String]);
+    if (!shaderLib) {
+      Log.report(logvisor::Fatal, fmt("error creating library: {}"), [[err localizedDescription] UTF8String]);
+    }
 
     NSString* funcName;
     switch (stage) {
@@ -1024,9 +1026,10 @@ protected:
     desc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
     NSError* err = nullptr;
     m_state = [ctx->m_dev newRenderPipelineStateWithDescriptor:desc error:&err];
-    if (err)
-      Log.report(logvisor::Fatal, fmt("error making shader pipeline: %s"),
+    if (err) {
+      Log.report(logvisor::Fatal, fmt("error making shader pipeline: {}"),
                  [[err localizedDescription] UTF8String]);
+    }
 
     MTLDepthStencilDescriptor* dsDesc = [MTLDepthStencilDescriptor new];
     switch (info.depthTest) {
@@ -1098,9 +1101,10 @@ class MetalTessellationShaderPipeline : public MetalShaderPipeline {
     NSError* err = nullptr;
     m_computeState = [ctx->m_dev newComputePipelineStateWithDescriptor:compDesc options:MTLPipelineOptionNone
                                                             reflection:nil error:&err];
-    if (err)
-      Log.report(logvisor::Fatal, fmt("error making compute pipeline: %s"),
+    if (err) {
+      Log.report(logvisor::Fatal, fmt("error making compute pipeline: {}"),
                  [[err localizedDescription] UTF8String]);
+    }
   }
 
   void draw(MetalCommandQueue& q, size_t start, size_t count);
@@ -1202,9 +1206,10 @@ struct MetalShaderDataBinding : GraphicsDataNode<IShaderDataBinding> {
       m_ubufOffs.reserve(ubufCount);
       for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-        if (ubufOffs[i] % 256)
-          Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset %d provided to newShaderDataBinding"),
-                     int(i));
+        if (ubufOffs[i] % 256) {
+          Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset {} provided to newShaderDataBinding"),
+                     i);
+        }
 #endif
         m_ubufOffs.push_back(ubufOffs[i]);
       }
@@ -1212,8 +1217,9 @@ struct MetalShaderDataBinding : GraphicsDataNode<IShaderDataBinding> {
     m_ubufs.reserve(ubufCount);
     for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-      if (!ubufs[i])
-        Log.report(logvisor::Fatal, fmt("null uniform-buffer %d provided to newShaderDataBinding"), int(i));
+      if (!ubufs[i]) {
+        Log.report(logvisor::Fatal, fmt("null uniform-buffer {} provided to newShaderDataBinding"), i);
+      }
 #endif
       m_ubufs.push_back(ubufs[i]);
     }
@@ -2056,17 +2062,17 @@ void MetalDataFactoryImpl::SetupGammaResources() {
     ObjToken<ITexture> texs[] = {{}, m_gammaLUT.get()};
     m_gammaBinding = ctx.newShaderDataBinding(m_gammaShader, m_gammaVBO.get(), {}, {},
                                               0, nullptr, nullptr, 2, texs, nullptr, nullptr);
-    
+
     Vert flipverts[4] = {{{-1.f, 1.f, 0.f, 1.f}, {0.f, 1.f, 0.f, 0.f}},
       {{1.f, 1.f, 0.f, 1.f}, {1.f, 1.f, 0.f, 0.f}},
       {{-1.f, -1.f, 0.f, 1.f}, {0.f, 0.f, 0.f, 0.f}},
       {{1.f, -1.f, 0.f, 1.f}, {1.f, 0.f, 0.f, 0.f}}};
     m_cubeFlipVBO = ctx.newStaticBuffer(BufferUse::Vertex, flipverts, 32, 4);
-    
+
     {
       fragmentMetal = MetalDataFactory::CompileMetal(CubeFlipFS, PipelineStage::Fragment);
       fragmentShader = ctx.newShaderStage(fragmentMetal, PipelineStage::Fragment);
-      
+
       MTLRenderPipelineDescriptor* desc = [MTLRenderPipelineDescriptor new];
       desc.vertexFunction = vertexShader.cast<MetalShaderStage>()->shader();
       desc.fragmentFunction = fragmentShader.cast<MetalShaderStage>()->shader();
@@ -2078,11 +2084,12 @@ void MetalDataFactoryImpl::SetupGammaResources() {
       desc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
       NSError* err = nullptr;
       m_cubeFlipShader = [m_ctx->m_dev newRenderPipelineStateWithDescriptor:desc error:&err];
-      if (err)
-        Log.report(logvisor::Fatal, fmt("error making shader pipeline: %s"),
+      if (err) {
+        Log.report(logvisor::Fatal, fmt("error making shader pipeline: {}"),
                    [[err localizedDescription] UTF8String]);
+      }
     }
-    
+
     return true;
   } BooTrace);
 }

--- a/lib/graphicsdev/Vulkan.cpp
+++ b/lib/graphicsdev/Vulkan.cpp
@@ -2668,9 +2668,10 @@ struct VulkanShaderDataBinding : GraphicsDataNode<IShaderDataBinding> {
       m_ubufOffs.reserve(ubufCount);
       for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-        if (ubufOffs[i] % 256)
+        if (ubufOffs[i] % 256) {
           Log.report(logvisor::Fatal, fmt("non-256-byte-aligned uniform-offset {} provided to newShaderDataBinding"),
-                     int(i));
+                     i);
+        }
 #endif
         std::array<VkDescriptorBufferInfo, 2> fillArr;
         fillArr.fill({VK_NULL_HANDLE, ubufOffs[i], (ubufSizes[i] + 255) & ~255});
@@ -2680,8 +2681,9 @@ struct VulkanShaderDataBinding : GraphicsDataNode<IShaderDataBinding> {
     m_ubufs.reserve(ubufCount);
     for (size_t i = 0; i < ubufCount; ++i) {
 #ifndef NDEBUG
-      if (!ubufs[i])
-        Log.report(logvisor::Fatal, fmt("null uniform-buffer {} provided to newShaderDataBinding"), int(i));
+      if (!ubufs[i]) {
+        Log.report(logvisor::Fatal, fmt("null uniform-buffer {} provided to newShaderDataBinding"), i);
+      }
 #endif
       m_ubufs.push_back(ubufs[i]);
     }

--- a/lib/inputdev/DolphinSmashAdapter.cpp
+++ b/lib/inputdev/DolphinSmashAdapter.cpp
@@ -55,7 +55,7 @@ void DolphinSmashAdapter::transferCycle() {
   if (recvSz != 37 || payload[0] != 0x21)
     return;
 
-  // printf("RECEIVED DATA %zu %02X\n", recvSz, payload[0]);
+  // fmt::print("RECEIVED DATA {} {:02X}\n", recvSz, payload[0]);
 
   std::lock_guard<std::mutex> lk(m_callbackLock);
   if (!m_callback)

--- a/lib/inputdev/DualshockPad.cpp
+++ b/lib/inputdev/DualshockPad.cpp
@@ -43,16 +43,20 @@ void DualshockPad::deviceDisconnected() {
 
 void DualshockPad::initialCycle() {
 #if 0
-    uint8_t setupCommand[5] = {0xF4, 0x42, 0x0c, 0x00, 0x00}; //Tells controller to start sending changes on in pipe
-    if (!sendHIDReport(setupCommand, 5, HIDReportType::Feature, 0xF4))
-    {
-        deviceError("Unable to send complete packet! Request size %x\n", sizeof(setupCommand));
-        return;
-    }
-    uint8_t btAddr[8];
-    receiveHIDReport(btAddr, sizeof(btAddr), HIDReportType::Feature, 0xF5);
-    for (int i = 0; i < 6; i++)
-        m_btAddress[5 - i] = btAddr[i + 2]; // Copy into buffer reversed, so it is LSB first
+  // Tells controller to start sending changes on in pipe
+  uint8_t setupCommand[5] = {0xF4, 0x42, 0x0c, 0x00, 0x00};
+
+  if (!sendHIDReport(setupCommand, 5, HIDReportType::Feature, 0xF4)) {
+    deviceError("Unable to send complete packet! Request size {:x}\n", sizeof(setupCommand));
+    return;
+  }
+
+  uint8_t btAddr[8];
+  receiveHIDReport(btAddr, sizeof(btAddr), HIDReportType::Feature, 0xF5);
+  for (int i = 0; i < 6; i++) {
+    // Copy into buffer reversed, so it is LSB first
+    m_btAddress[5 - i] = btAddr[i + 2];
+  }
 #endif
 }
 

--- a/lib/inputdev/HIDListenerIOKit.cpp
+++ b/lib/inputdev/HIDListenerIOKit.cpp
@@ -108,7 +108,7 @@ class HIDListenerIOKit : public IHIDListener {
 
       listener->m_finder._insertToken(std::make_unique<DeviceToken>(DeviceType::USB, vid, pid, vstr, pstr, devPath));
 
-      // printf("ADDED %08X %s\n", obj.get(), devPath);
+      // fmt::print(fmt("ADDED {:08X} {}\n"), obj.get(), devPath);
     }
   }
 
@@ -124,7 +124,7 @@ class HIDListenerIOKit : public IHIDListener {
       if (IORegistryEntryGetPath(obj.get(), kIOServicePlane, devPath) != 0)
         continue;
       listener->m_finder._removeToken(devPath);
-      // printf("REMOVED %08X %s\n", obj.get(), devPath);
+      // fmt::print(fmt("REMOVED {:08X} {}\n"), obj.get(), devPath);
     }
   }
 
@@ -191,7 +191,7 @@ class HIDListenerIOKit : public IHIDListener {
 
       listener->m_finder._insertToken(std::make_unique<DeviceToken>(DeviceType::HID, vidv, pidv, vstr, pstr, devPath));
 
-      // printf("ADDED %08X %s\n", obj, devPath);
+      // fmt::print(fmt("ADDED {:08X} {}\n"), obj, devPath);
     }
   }
 
@@ -207,7 +207,7 @@ class HIDListenerIOKit : public IHIDListener {
       if (IORegistryEntryGetPath(obj.get(), kIOServicePlane, devPath) != 0)
         continue;
       listener->m_finder._removeToken(devPath);
-      // printf("REMOVED %08X %s\n", obj, devPath);
+      // fmt::print(fmt("REMOVED {:08X} {}\n"), obj, devPath);
     }
   }
 

--- a/lib/inputdev/HIDListenerUdev.cpp
+++ b/lib/inputdev/HIDListenerUdev.cpp
@@ -118,14 +118,14 @@ class HIDListenerUdev final : public IHIDListener {
     }
 
 #if 0
-        udev_list_entry* att = nullptr;
-        udev_list_entry_foreach(att, attrs)
-        {
-            const char* name = udev_list_entry_get_name(att);
-            const char* val = udev_list_entry_get_value(att);
-            fprintf(stderr, "%s %s\n", name, val);
-        }
-        fprintf(stderr, "\n\n");
+    udev_list_entry* att = nullptr;
+    udev_list_entry_foreach(att, attrs)
+    {
+      const char* name = udev_list_entry_get_name(att);
+      const char* val = udev_list_entry_get_value(att);
+      fmt::print(stderr, fmt("{} {}\n"), name, val);
+    }
+    std::fputs("\n\n", stderr);
 #endif
 
     m_finder._insertToken(std::make_unique<DeviceToken>(type, vid, pid, manuf, product, devPath));

--- a/lib/win/WindowWin32.cpp
+++ b/lib/win/WindowWin32.cpp
@@ -350,8 +350,11 @@ struct GraphicsContextWin32Vulkan : GraphicsContextWin32 {
   bool m_vsyncRunning;
 
   static void ThrowIfFailed(VkResult res) {
-    if (res != VK_SUCCESS)
-      Log.report(logvisor::Fatal, fmt("%d\n"), res);
+    if (res == VK_SUCCESS) {
+      return;
+    }
+
+    Log.report(logvisor::Fatal, fmt("{}\n"), res);
   }
 
 public:


### PR DESCRIPTION
Corrects a few fmt calls to use fmt's specifiers. This also converts instances of printf over to fmt::print

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/27)
<!-- Reviewable:end -->
