### PR TITLE
MIDIDecoder: Make readContinuedValue internal + other cleanups

### DIFF
--- a/include/boo/audiodev/MIDIDecoder.hpp
+++ b/include/boo/audiodev/MIDIDecoder.hpp
@@ -9,8 +9,6 @@ class IMIDIReader;
 class MIDIDecoder {
   IMIDIReader& m_out;
   uint8_t m_status = 0;
-  bool _readContinuedValue(std::vector<uint8_t>::const_iterator& it, std::vector<uint8_t>::const_iterator end,
-                           uint32_t& valOut);
 
 public:
   MIDIDecoder(IMIDIReader& out) : m_out(out) {}

--- a/lib/audiodev/MIDIDecoder.cpp
+++ b/lib/audiodev/MIDIDecoder.cpp
@@ -40,7 +40,7 @@ std::optional<uint32_t> readContinuedValue(std::vector<uint8_t>::const_iterator&
 
 std::vector<uint8_t>::const_iterator MIDIDecoder::receiveBytes(std::vector<uint8_t>::const_iterator begin,
                                                                std::vector<uint8_t>::const_iterator end) {
-  std::vector<uint8_t>::const_iterator it = begin;
+  auto it = begin;
   while (it != end) {
     uint8_t a = *it++;
     uint8_t b;

--- a/lib/audiodev/MIDIDecoder.cpp
+++ b/lib/audiodev/MIDIDecoder.cpp
@@ -7,11 +7,11 @@
 
 
 namespace boo {
-
+namespace {
 constexpr uint8_t clamp7(uint8_t val) { return std::max(0, std::min(127, int(val))); }
 
-bool MIDIDecoder::_readContinuedValue(std::vector<uint8_t>::const_iterator& it,
-                                      std::vector<uint8_t>::const_iterator end, uint32_t& valOut) {
+bool readContinuedValue(std::vector<uint8_t>::const_iterator& it, std::vector<uint8_t>::const_iterator end,
+                        uint32_t& valOut) {
   uint8_t a = *it++;
   valOut = a & 0x7f;
 
@@ -33,6 +33,7 @@ bool MIDIDecoder::_readContinuedValue(std::vector<uint8_t>::const_iterator& it,
 
   return true;
 }
+} // Anonymous namespace
 
 std::vector<uint8_t>::const_iterator MIDIDecoder::receiveBytes(std::vector<uint8_t>::const_iterator begin,
                                                                std::vector<uint8_t>::const_iterator end) {
@@ -52,7 +53,7 @@ std::vector<uint8_t>::const_iterator MIDIDecoder::receiveBytes(std::vector<uint8
       a = *it++;
 
       uint32_t length;
-      _readContinuedValue(it, end, length);
+      readContinuedValue(it, end, length);
       it += length;
     } else {
       uint8_t chan = m_status & 0xf;
@@ -125,7 +126,7 @@ std::vector<uint8_t>::const_iterator MIDIDecoder::receiveBytes(std::vector<uint8
         switch (Status(m_status & 0xff)) {
         case Status::SysEx: {
           uint32_t len;
-          if (!_readContinuedValue(it, end, len) || end - it < len)
+          if (!readContinuedValue(it, end, len) || end - it < len)
             return begin;
           m_out.sysex(&*it, len);
           break;

--- a/lib/audiodev/MIDIDecoder.cpp
+++ b/lib/audiodev/MIDIDecoder.cpp
@@ -1,6 +1,7 @@
 #include "boo/audiodev/MIDIDecoder.hpp"
 
 #include <algorithm>
+#include <optional>
 
 #include "boo/audiodev/IMIDIReader.hpp"
 #include "lib/audiodev/MIDICommon.hpp"
@@ -10,28 +11,30 @@ namespace boo {
 namespace {
 constexpr uint8_t clamp7(uint8_t val) { return std::max(0, std::min(127, int(val))); }
 
-bool readContinuedValue(std::vector<uint8_t>::const_iterator& it, std::vector<uint8_t>::const_iterator end,
-                        uint32_t& valOut) {
+std::optional<uint32_t> readContinuedValue(std::vector<uint8_t>::const_iterator& it,
+                                           std::vector<uint8_t>::const_iterator end) {
   uint8_t a = *it++;
-  valOut = a & 0x7f;
+  uint32_t valOut = a & 0x7f;
 
-  if (a & 0x80) {
-    if (it == end)
-      return false;
+  if ((a & 0x80) != 0) {
+    if (it == end) {
+      return std::nullopt;
+    }
     valOut <<= 7;
     a = *it++;
     valOut |= a & 0x7f;
 
-    if (a & 0x80) {
-      if (it == end)
-        return false;
+    if ((a & 0x80) != 0) {
+      if (it == end) {
+        return std::nullopt;
+      }
       valOut <<= 7;
       a = *it++;
       valOut |= a & 0x7f;
     }
   }
 
-  return true;
+  return valOut;
 }
 } // Anonymous namespace
 
@@ -52,9 +55,8 @@ std::vector<uint8_t>::const_iterator MIDIDecoder::receiveBytes(std::vector<uint8
         return begin;
       a = *it++;
 
-      uint32_t length;
-      readContinuedValue(it, end, length);
-      it += length;
+      const auto length = readContinuedValue(it, end);
+      it += *length;
     } else {
       uint8_t chan = m_status & 0xf;
       switch (Status(m_status & 0xf0)) {
@@ -125,10 +127,11 @@ std::vector<uint8_t>::const_iterator MIDIDecoder::receiveBytes(std::vector<uint8
       case Status::SysEx: {
         switch (Status(m_status & 0xff)) {
         case Status::SysEx: {
-          uint32_t len;
-          if (!readContinuedValue(it, end, len) || end - it < len)
+          const auto len = readContinuedValue(it, end);
+          if (!len || end - it < *len) {
             return begin;
-          m_out.sysex(&*it, len);
+          }
+          m_out.sysex(&*it, *len);
           break;
         }
         case Status::TimecodeQuarterFrame: {

--- a/lib/audiodev/MIDIDecoder.cpp
+++ b/lib/audiodev/MIDIDecoder.cpp
@@ -9,7 +9,7 @@
 
 namespace boo {
 namespace {
-constexpr uint8_t clamp7(uint8_t val) { return std::max(0, std::min(127, int(val))); }
+constexpr uint8_t clamp7(uint8_t val) { return std::clamp(val, uint8_t{0}, uint8_t{127}); }
 
 std::optional<uint32_t> readContinuedValue(std::vector<uint8_t>::const_iterator& it,
                                            std::vector<uint8_t>::const_iterator end) {


### PR DESCRIPTION
`readContinuedValue()` doesn't modify any class state, so it can be removed from the interface entirely and made internal. While we're in the same area, we can convert it to use `std::optional` instead of a bool return value and an out reference. We can also simplify the implementation of `clamp7()` with the use of `std::clamp`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/33)
<!-- Reviewable:end -->
