### PR TITLE
ApplicationWin32/WindowWin32: Get/SetWindowLong -> Get/SetWindowLongPtr

### DIFF
--- a/include/boo/graphicsdev/Vulkan.hpp
+++ b/include/boo/graphicsdev/Vulkan.hpp
@@ -85,8 +85,8 @@ struct VulkanContext {
 #if _WIN32
     HWND m_hwnd = 0;
     bool m_fs = false;
-    LONG m_fsStyle;
-    LONG m_fsExStyle;
+    LONG_PTR m_fsStyle;
+    LONG_PTR m_fsExStyle;
     RECT m_fsRect;
     int m_fsCountDown = 0;
 #endif

--- a/lib/win/ApplicationWin32.cpp
+++ b/lib/win/ApplicationWin32.cpp
@@ -339,9 +339,10 @@ public:
       win.m_fsExStyle = GetWindowLong(win.m_hwnd, GWL_EXSTYLE);
       GetWindowRect(win.m_hwnd, &win.m_fsRect);
 
-      SetWindowLong(win.m_hwnd, GWL_STYLE, win.m_fsStyle & ~(WS_CAPTION | WS_THICKFRAME));
-      SetWindowLong(win.m_hwnd, GWL_EXSTYLE,
-                    win.m_fsExStyle & ~(WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE));
+      SetWindowLongPtr(win.m_hwnd, GWL_STYLE, win.m_fsStyle & ~(WS_CAPTION | WS_THICKFRAME));
+      SetWindowLongPtr(win.m_hwnd, GWL_EXSTYLE,
+                       win.m_fsExStyle &
+                           ~(WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE));
 
       MONITORINFO monitor_info;
       monitor_info.cbSize = sizeof(monitor_info);
@@ -353,8 +354,8 @@ public:
 
       win.m_fs = true;
     } else {
-      SetWindowLong(win.m_hwnd, GWL_STYLE, win.m_fsStyle);
-      SetWindowLong(win.m_hwnd, GWL_EXSTYLE, win.m_fsExStyle);
+      SetWindowLongPtr(win.m_hwnd, GWL_STYLE, win.m_fsStyle);
+      SetWindowLongPtr(win.m_hwnd, GWL_EXSTYLE, win.m_fsExStyle);
 
       SetWindowPos(win.m_hwnd, nullptr, win.m_fsRect.left, win.m_fsRect.top, win.m_fsRect.right - win.m_fsRect.left,
                    win.m_fsRect.bottom - win.m_fsRect.top, SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);

--- a/lib/win/Win32Common.hpp
+++ b/lib/win/Win32Common.hpp
@@ -39,8 +39,8 @@ struct OGLContext {
     size_t width, height;
 
     bool m_fs = false;
-    LONG m_fsStyle;
-    LONG m_fsExStyle;
+    LONG_PTR m_fsStyle;
+    LONG_PTR m_fsExStyle;
     RECT m_fsRect;
     int m_fsCountDown = 0;
   };

--- a/lib/win/WindowWin32.cpp
+++ b/lib/win/WindowWin32.cpp
@@ -1300,35 +1300,43 @@ public:
   ETouchType getTouchType() const override { return ETouchType::None; }
 
   void setStyle(EWindowStyle style) override {
-    LONG sty = GetWindowLong(m_hwnd, GWL_STYLE);
+    LONG_PTR sty = GetWindowLongPtr(m_hwnd, GWL_STYLE);
 
-    if ((style & EWindowStyle::Titlebar) != EWindowStyle::None)
+    if ((style & EWindowStyle::Titlebar) != EWindowStyle::None) {
       sty |= WS_CAPTION;
-    else
+    } else {
       sty &= ~WS_CAPTION;
+    }
 
-    if ((style & EWindowStyle::Resize) != EWindowStyle::None)
+    if ((style & EWindowStyle::Resize) != EWindowStyle::None) {
       sty |= WS_THICKFRAME;
-    else
+    } else {
       sty &= ~WS_THICKFRAME;
+    }
 
-    if ((style & EWindowStyle::Close) != EWindowStyle::None)
+    if ((style & EWindowStyle::Close) != EWindowStyle::None) {
       sty |= (WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
-    else
+    } else {
       sty &= ~(WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+    }
 
-    SetWindowLong(m_hwnd, GWL_STYLE, sty);
+    SetWindowLongPtr(m_hwnd, GWL_STYLE, sty);
   }
 
   EWindowStyle getStyle() const override {
-    LONG sty = GetWindowLong(m_hwnd, GWL_STYLE);
+    const LONG_PTR sty = GetWindowLongPtr(m_hwnd, GWL_STYLE);
+
     EWindowStyle retval = EWindowStyle::None;
-    if ((sty & WS_CAPTION) != 0)
+    if ((sty & WS_CAPTION) != 0) {
       retval |= EWindowStyle::Titlebar;
-    if ((sty & WS_THICKFRAME) != 0)
+    }
+    if ((sty & WS_THICKFRAME) != 0) {
       retval |= EWindowStyle::Resize;
-    if ((sty & WS_SYSMENU))
+    }
+    if ((sty & WS_SYSMENU)) {
       retval |= EWindowStyle::Close;
+    }
+
     return retval;
   }
 


### PR DESCRIPTION
[Get/SetWindowLong](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlonga) is superseded on 64-bit Windows platform with [Get/SetWindowLongPtr](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra). These are trivial to migrate over and have been available since Windows 2000 Professional, so there's no need to worry about breaking meaningful platform support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/37)
<!-- Reviewable:end -->
