### PR TITLE
NintendoPowerA: Use std::memcpy within transferCycle()

### DIFF
--- a/include/boo/inputdev/NintendoPowerA.hpp
+++ b/include/boo/inputdev/NintendoPowerA.hpp
@@ -34,7 +34,7 @@ struct INintendoPowerACallback {
 };
 
 class NintendoPowerA final : public TDeviceBase<INintendoPowerACallback> {
-  NintendoPowerAState m_last;
+  NintendoPowerAState m_last{};
   void deviceDisconnected() override;
   void initialCycle() override;
   void transferCycle() override;
@@ -42,7 +42,7 @@ class NintendoPowerA final : public TDeviceBase<INintendoPowerACallback> {
   void receivedHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) override;
 
 public:
-  NintendoPowerA(DeviceToken*);
+  explicit NintendoPowerA(DeviceToken*);
   ~NintendoPowerA() override;
 };
 } // namespace boo

--- a/lib/inputdev/NintendoPowerA.cpp
+++ b/lib/inputdev/NintendoPowerA.cpp
@@ -1,5 +1,6 @@
 #include "boo/inputdev/NintendoPowerA.hpp"
 
+#include <array>
 #include <cstring>
 
 #include "boo/inputdev/DeviceSignature.hpp"
@@ -20,9 +21,9 @@ void NintendoPowerA::deviceDisconnected() {
 void NintendoPowerA::initialCycle() {}
 
 void NintendoPowerA::transferCycle() {
-  uint8_t payload[8];
-  size_t recvSz = receiveUSBInterruptTransfer(payload, sizeof(payload));
-  if (recvSz != 8) {
+  std::array<uint8_t, 8> payload;
+  const size_t recvSz = receiveUSBInterruptTransfer(payload.data(), payload.size());
+  if (recvSz != payload.size()) {
     return;
   }
 

--- a/lib/inputdev/NintendoPowerA.cpp
+++ b/lib/inputdev/NintendoPowerA.cpp
@@ -8,7 +8,7 @@ namespace boo {
 NintendoPowerA::NintendoPowerA(DeviceToken* token)
 : TDeviceBase<INintendoPowerACallback>(dev_typeid(NintendoPowerA), token) {}
 
-NintendoPowerA::~NintendoPowerA() {}
+NintendoPowerA::~NintendoPowerA() = default;
 
 void NintendoPowerA::deviceDisconnected() {
   std::lock_guard<std::mutex> lk(m_callbackLock);

--- a/lib/inputdev/NintendoPowerA.cpp
+++ b/lib/inputdev/NintendoPowerA.cpp
@@ -27,7 +27,8 @@ void NintendoPowerA::transferCycle() {
     return;
   }
 
-  NintendoPowerAState state = *reinterpret_cast<NintendoPowerAState*>(&payload);
+  NintendoPowerAState state;
+  std::memcpy(&state, payload.data(), sizeof(state));
 
   std::lock_guard lk{m_callbackLock};
   if (state != m_last && m_callback != nullptr) {
@@ -41,7 +42,7 @@ void NintendoPowerA::finalCycle() {}
 void NintendoPowerA::receivedHIDReport(const uint8_t* data, size_t length, HIDReportType tp, uint32_t message) {}
 
 bool NintendoPowerAState::operator==(const NintendoPowerAState& other) const {
-  return memcmp(this, &other, sizeof(NintendoPowerAState)) == 0;
+  return std::memcmp(this, &other, sizeof(NintendoPowerAState)) == 0;
 }
 
 bool NintendoPowerAState::operator!=(const NintendoPowerAState& other) const { return !operator==(other); }

--- a/lib/inputdev/NintendoPowerA.cpp
+++ b/lib/inputdev/NintendoPowerA.cpp
@@ -11,9 +11,10 @@ NintendoPowerA::NintendoPowerA(DeviceToken* token)
 NintendoPowerA::~NintendoPowerA() = default;
 
 void NintendoPowerA::deviceDisconnected() {
-  std::lock_guard<std::mutex> lk(m_callbackLock);
-  if (m_callback)
+  std::lock_guard lk{m_callbackLock};
+  if (m_callback != nullptr) {
     m_callback->controllerDisconnected();
+  }
 }
 
 void NintendoPowerA::initialCycle() {}
@@ -21,14 +22,16 @@ void NintendoPowerA::initialCycle() {}
 void NintendoPowerA::transferCycle() {
   uint8_t payload[8];
   size_t recvSz = receiveUSBInterruptTransfer(payload, sizeof(payload));
-  if (recvSz != 8)
+  if (recvSz != 8) {
     return;
+  }
 
   NintendoPowerAState state = *reinterpret_cast<NintendoPowerAState*>(&payload);
 
-  std::lock_guard<std::mutex> lk(m_callbackLock);
-  if (state != m_last && m_callback)
+  std::lock_guard lk{m_callbackLock};
+  if (state != m_last && m_callback != nullptr) {
     m_callback->controllerUpdate(state);
+  }
   m_last = state;
 }
 


### PR DESCRIPTION
Eliminates undefined behavior within the function due to language type-punning rules. While we're at it, we can also do some C++17-related tidying up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/boo/38)
<!-- Reviewable:end -->
